### PR TITLE
CP-8639: Enable coredumps

### DIFF
--- a/scripts/init.d-rrdd-gpumon
+++ b/scripts/init.d-rrdd-gpumon
@@ -20,6 +20,9 @@ PID_FILE="/var/run/${NAME}.pid"
 # lock file
 SUBSYS_FILE="/var/lock/subsys/${NAME}"
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
 	echo -n $"Starting XCP RRDD plugin ${NAME}: "
 	


### PR DESCRIPTION
Call ulimit -c unlimited in the init script, so core files can be written.

See also https://github.com/xapi-project/xen-api/pull/1777
