### PR TITLE
gpumon.ml: fix incorrect word in error message

### DIFF
--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -90,7 +90,7 @@ let load_config () =
 	match Gpumon_config.of_file nvidia_config_path with
 	| `Ok config -> [nvidia_vendor_id, config]
 	| `Error `Does_not_exist ->
-		Process.D.error "Gpumon_config file %s not found" nvidia_config_path;
+		Process.D.error "Config file %s not found" nvidia_config_path;
 		Process.D.warn "Using default config";
 		default_config
 	| `Error (`Parse_failure msg) ->


### PR DESCRIPTION
I accidentally renamed the "Config" word in that error message when
using sed to rename the Config module to Gpumon_config.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>