### PR TITLE
CA-280209 NVidia vGPU migration driver: use >= 390

### DIFF
--- a/gpumon/gpumon_server.ml
+++ b/gpumon/gpumon_server.ml
@@ -23,7 +23,7 @@ module Make(I: Interface) = struct
 
   module Nvidia = struct
     
-    let host_driver_supporting_migration = 385
+    let host_driver_supporting_migration = 390
     (** Smallest major version of the host driver that supports migration *)
 
     let get_interface_exn () = 


### PR DESCRIPTION
For CA-275983 we've added a check of the NVIDIA vGPU host driver
version, to decide whether a driver release supports vGPU migration.
However, we've now learned from NVidia that they will make further
releases of their driver that don't support migration above 385. NVidia
have advised that the first driver to support vGPU migration will be
390.

This commit changes the one line that defines the version number to be
checked.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>