### PR TITLE
CP-26717: Port Gpumon to PPX-based RPCs

### DIFF
--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -308,12 +308,12 @@ let () =
 	let module Gpumon_server = Gpumon_server.Make(struct
 		let interface = maybe_interface
 	end) in
-	let module Server = Gpumon_interface.Server(Gpumon_server) in
+	let module Server = Gpumon_interface.RPC_API(Idl.GenServerExn ()) in
 	let server = Xcp_service.make
 		~path:Gpumon_interface.xml_path
 		~queue_name:Gpumon_interface.queue_name
-		~rpc_fn:(Server.process ())
-		() 
+		~rpc_fn:(Idl.server Server.implementation)
+		()
 	in
 	let _ = (handle_shutdown stop_handler (); start server) in
 

--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -7,52 +7,52 @@ module Process = Process(struct let name = plugin_name end)
 let nvidia_vendor_id = 0x10del
 
 let default_config : (int32 * Gpumon_config.config) list =
-	let open Gpumon_config in [
-		(* NVIDIA Corporation *)
-		nvidia_vendor_id,
-		{
-			device_types = [
-				(* GRID K1 *)
-				{
-					device_id = 0x0ff2l;
-					subsystem_device_id = Any;
-					metrics = [
-						Memory Free;
-						Memory Used;
-						Other Temperature;
-						Other PowerUsage;
-						Utilisation Compute;
-						Utilisation MemoryIO;
-					];
-				};
-				(* GRID K2 *)
-				{
-					device_id = 0x11bfl;
-					subsystem_device_id = Any;
-					metrics = [
-						Memory Free;
-						Memory Used;
-						Other Temperature;
-						Other PowerUsage;
-						Utilisation Compute;
-						Utilisation MemoryIO;
-					];
-				};
-			]
-		}
-	]
+  let open Gpumon_config in [
+    (* NVIDIA Corporation *)
+    nvidia_vendor_id,
+    {
+      device_types = [
+        (* GRID K1 *)
+        {
+          device_id = 0x0ff2l;
+          subsystem_device_id = Any;
+          metrics = [
+            Memory Free;
+            Memory Used;
+            Other Temperature;
+            Other PowerUsage;
+            Utilisation Compute;
+            Utilisation MemoryIO;
+          ];
+        };
+        (* GRID K2 *)
+        {
+          device_id = 0x11bfl;
+          subsystem_device_id = Any;
+          metrics = [
+            Memory Free;
+            Memory Used;
+            Other Temperature;
+            Other PowerUsage;
+            Utilisation Compute;
+            Utilisation MemoryIO;
+          ];
+        };
+      ]
+    }
+  ]
 
 let categorise_metrics =
-	List.fold_left
-		(fun (memory_metrics, other_metrics, utilisation_metrics) metric ->
-			match metric with
-			| Gpumon_config.Memory x ->
-				x :: memory_metrics, other_metrics, utilisation_metrics
-			| Gpumon_config.Other x ->
-				memory_metrics, x :: other_metrics, utilisation_metrics
-			| Gpumon_config.Utilisation x ->
-				memory_metrics, other_metrics, x :: utilisation_metrics)
-		([], [], [])
+  List.fold_left
+    (fun (memory_metrics, other_metrics, utilisation_metrics) metric ->
+       match metric with
+       | Gpumon_config.Memory x ->
+         x :: memory_metrics, other_metrics, utilisation_metrics
+       | Gpumon_config.Other x ->
+         memory_metrics, x :: other_metrics, utilisation_metrics
+       | Gpumon_config.Utilisation x ->
+         memory_metrics, other_metrics, x :: utilisation_metrics)
+    ([], [], [])
 
 (** NVML returns the PCI ID and PCI subsystem ID as int32s, where the most
  *  significant 16 bits make up the device ID and the least significant 16 bits
@@ -62,26 +62,26 @@ let categorise_metrics =
  *  If all these IDs match, the required list of metrics for this device is
  *  returned. *)
 let get_required_metrics config pci_info =
-	let vendor_id = Int32.logand 0xffffl pci_info.Nvml.pci_device_id in
-	let device_id = Int32.shift_right_logical pci_info.Nvml.pci_device_id 16 in
-	let subsystem_device_id =
-		Int32.shift_right_logical pci_info.Nvml.pci_subsystem_id 16 in
-	try
-		let open Gpumon_config in
-		let vendor_config = List.assoc vendor_id config in
-		let device =
-			List.find
-				(fun device ->
-					(* Check that the device ID matches. *)
-					device.device_id = device_id &&
-					(* Check that the subsystem device ID matches, if necessary. *)
-					(match device.subsystem_device_id with
-					| Match id -> id = subsystem_device_id
-					| Any -> true))
-				vendor_config.device_types
-		in
-		Some (categorise_metrics device.metrics)
-	with Not_found -> None
+  let vendor_id = Int32.logand 0xffffl pci_info.Nvml.pci_device_id in
+  let device_id = Int32.shift_right_logical pci_info.Nvml.pci_device_id 16 in
+  let subsystem_device_id =
+    Int32.shift_right_logical pci_info.Nvml.pci_subsystem_id 16 in
+  try
+    let open Gpumon_config in
+    let vendor_config = List.assoc vendor_id config in
+    let device =
+      List.find
+        (fun device ->
+           (* Check that the device ID matches. *)
+           device.device_id = device_id &&
+           (* Check that the subsystem device ID matches, if necessary. *)
+           (match device.subsystem_device_id with
+            | Match id -> id = subsystem_device_id
+            | Any -> true))
+        vendor_config.device_types
+    in
+    Some (categorise_metrics device.metrics)
+  with Not_found -> None
 
 let nvidia_config_path = "/usr/share/nvidia/monitoring.conf"
 
@@ -90,259 +90,259 @@ let nvidia_config_path = "/usr/share/nvidia/monitoring.conf"
  *  expected config file format. *)
 let load_config () =
   let open Rresult in
-	match Gpumon_config.of_file nvidia_config_path with
-	| Ok config -> [nvidia_vendor_id, config]
-	| Error `Does_not_exist ->
-		Process.D.error "Config file %s not found" nvidia_config_path;
-		Process.D.warn "Using default config";
-		default_config
-	| Error (`Parse_failure msg) ->
-		Process.D.error "Caught exception parsing config file: %s" msg;
-		Process.D.warn "Using default config";
-		default_config
-	| Error (`Unknown_version version) ->
-		Process.D.error "Unknown config file version: %s" version;
-		Process.D.warn "Using default config";
-		default_config
+  match Gpumon_config.of_file nvidia_config_path with
+  | Ok config -> [nvidia_vendor_id, config]
+  | Error `Does_not_exist ->
+    Process.D.error "Config file %s not found" nvidia_config_path;
+    Process.D.warn "Using default config";
+    default_config
+  | Error (`Parse_failure msg) ->
+    Process.D.error "Caught exception parsing config file: %s" msg;
+    Process.D.warn "Using default config";
+    default_config
+  | Error (`Unknown_version version) ->
+    Process.D.error "Unknown config file version: %s" version;
+    Process.D.warn "Using default config";
+    default_config
 
 type gpu = {
-	device: Nvml.device;
-	bus_id: string;
-	bus_id_escaped: string;
-	memory_metrics: Gpumon_config.memory_metric list;
-	utilisation_metrics: Gpumon_config.utilisation_metric list;
-	other_metrics: Gpumon_config.other_metric list;
+  device: Nvml.device;
+  bus_id: string;
+  bus_id_escaped: string;
+  memory_metrics: Gpumon_config.memory_metric list;
+  utilisation_metrics: Gpumon_config.utilisation_metric list;
+  other_metrics: Gpumon_config.other_metric list;
 }
 
 (* Adding colons to datasource names confuses RRD parsers, so replace all
  * colons with "/" *)
 let escape_bus_id bus_id =
-	String.concat "/" (Stdext.Xstringext.String.split ':' bus_id)
+  String.concat "/" (Stdext.Xstringext.String.split ':' bus_id)
 
 (** Get the list of devices recognised by NVML. *)
 let get_gpus interface =
-	let config = load_config () in
-	let device_count = Nvml.device_get_count interface in
-	let rec make_gpu_list acc index =
-		if index >= 0 then begin
-			let device = Nvml.device_get_handle_by_index interface index in
-			let pci_info = Nvml.device_get_pci_info interface device in
-			match get_required_metrics config pci_info with
-			| Some (memory_metrics, other_metrics, utilisation_metrics) -> begin
-				Nvml.device_set_persistence_mode interface device Nvml.Enabled;
-				let bus_id = String.lowercase pci_info.Nvml.bus_id in
-				let gpu = {
-					device;
-					bus_id;
-					bus_id_escaped = escape_bus_id bus_id;
-					memory_metrics;
-					other_metrics;
-					utilisation_metrics;
-				} in
-				make_gpu_list
-					(gpu :: acc)
-					(index - 1)
-			end
-			| None -> make_gpu_list acc (index - 1)
-		end else acc
-	in
-	make_gpu_list [] (device_count - 1)
+  let config = load_config () in
+  let device_count = Nvml.device_get_count interface in
+  let rec make_gpu_list acc index =
+    if index >= 0 then begin
+      let device = Nvml.device_get_handle_by_index interface index in
+      let pci_info = Nvml.device_get_pci_info interface device in
+      match get_required_metrics config pci_info with
+      | Some (memory_metrics, other_metrics, utilisation_metrics) -> begin
+          Nvml.device_set_persistence_mode interface device Nvml.Enabled;
+          let bus_id = String.lowercase pci_info.Nvml.bus_id in
+          let gpu = {
+            device;
+            bus_id;
+            bus_id_escaped = escape_bus_id bus_id;
+            memory_metrics;
+            other_metrics;
+            utilisation_metrics;
+          } in
+          make_gpu_list
+            (gpu :: acc)
+            (index - 1)
+        end
+      | None -> make_gpu_list acc (index - 1)
+    end else acc
+  in
+  make_gpu_list [] (device_count - 1)
 
 (** Generate datasources for one GPU. *)
 let generate_gpu_dss interface gpu =
-	let memory_dss =
-		match gpu.memory_metrics with
-		| [] -> []
-		| metrics ->
-			let memory_info = Nvml.device_get_memory_info interface gpu.device in
-			List.map
-				(function
-					| Gpumon_config.Free ->
-						Rrd.Host,
-						Ds.ds_make
-							~name:("gpu_memory_free_" ^ gpu.bus_id_escaped)
-							~description:"Unallocated framebuffer memory"
-							~value:(Rrd.VT_Int64 memory_info.Nvml.free)
-							~ty:Rrd.Gauge
-							~default:false
-							~units:"B" ()
-					| Gpumon_config.Used ->
-						Rrd.Host,
-						Ds.ds_make
-							~name:("gpu_memory_used_" ^ gpu.bus_id_escaped)
-							~description:"Allocated framebuffer memory"
-							~value:(Rrd.VT_Int64 memory_info.Nvml.used)
-							~ty:Rrd.Gauge
-							~default:false
-							~units:"B" ())
-				metrics
-	in
-	let other_dss =
-		List.map
-			(function
-				| Gpumon_config.PowerUsage ->
-					let power_usage = Nvml.device_get_power_usage interface gpu.device in
-					Rrd.Host,
-					Ds.ds_make
-						~name:("gpu_power_usage_" ^ gpu.bus_id_escaped)
-						~description:"Power usage of this GPU"
-						~value:(Rrd.VT_Int64 (Int64.of_int power_usage))
-						~ty:Rrd.Gauge
-						~default:false
-						~units:"mW" ()
-				| Gpumon_config.Temperature ->
-					let temperature = Nvml.device_get_temperature interface gpu.device in
-					Rrd.Host,
-					Ds.ds_make
-						~name:("gpu_temperature_" ^ gpu.bus_id_escaped)
-						~description:"Temperature of this GPU"
-						~value:(Rrd.VT_Int64 (Int64.of_int temperature))
-						~ty:Rrd.Gauge
-						~default:false
-						~units:"°C" ())
-			gpu.other_metrics
-	in
-	let utilisation_dss =
-		match gpu.utilisation_metrics with
-		| [] -> []
-		| metrics ->
-			let utilization =
-				Nvml.device_get_utilization_rates interface gpu.device in
-			List.map
-				(function
-					| Gpumon_config.Compute ->
-						Rrd.Host,
-						Ds.ds_make
-							~name:("gpu_utilisation_compute_" ^ gpu.bus_id_escaped)
-							~description:("Proportion of time over the past sample period during"^
-								" which one or more kernels was executing on this GPU")
-							~value:(Rrd.VT_Float ((float_of_int utilization.Nvml.gpu) /. 100.0))
-							~ty:Rrd.Gauge
-							~default:false
-							~min:0.0
-							~max:1.0
-							~units:"(fraction)" ()
-					| Gpumon_config.MemoryIO ->
-						Rrd.Host,
-						Ds.ds_make
-							~name:("gpu_utilisation_memory_io_" ^ gpu.bus_id_escaped)
-							~description:("Proportion of time over the past sample period during"^
-								" which global (device) memory was being read or written on this GPU")
-							~value:(Rrd.VT_Float ((float_of_int utilization.Nvml.memory) /. 100.0))
-							~ty:Rrd.Gauge
-							~default:false
-							~min:0.0
-							~max:1.0
-							~units:"(fraction)" ())
-				metrics
-	in
-	List.fold_left
-		(fun acc metrics -> List.rev_append metrics acc)
-		[] [memory_dss; other_dss; utilisation_dss]
+  let memory_dss =
+    match gpu.memory_metrics with
+    | [] -> []
+    | metrics ->
+      let memory_info = Nvml.device_get_memory_info interface gpu.device in
+      List.map
+        (function
+          | Gpumon_config.Free ->
+            Rrd.Host,
+            Ds.ds_make
+              ~name:("gpu_memory_free_" ^ gpu.bus_id_escaped)
+              ~description:"Unallocated framebuffer memory"
+              ~value:(Rrd.VT_Int64 memory_info.Nvml.free)
+              ~ty:Rrd.Gauge
+              ~default:false
+              ~units:"B" ()
+          | Gpumon_config.Used ->
+            Rrd.Host,
+            Ds.ds_make
+              ~name:("gpu_memory_used_" ^ gpu.bus_id_escaped)
+              ~description:"Allocated framebuffer memory"
+              ~value:(Rrd.VT_Int64 memory_info.Nvml.used)
+              ~ty:Rrd.Gauge
+              ~default:false
+              ~units:"B" ())
+        metrics
+  in
+  let other_dss =
+    List.map
+      (function
+        | Gpumon_config.PowerUsage ->
+          let power_usage = Nvml.device_get_power_usage interface gpu.device in
+          Rrd.Host,
+          Ds.ds_make
+            ~name:("gpu_power_usage_" ^ gpu.bus_id_escaped)
+            ~description:"Power usage of this GPU"
+            ~value:(Rrd.VT_Int64 (Int64.of_int power_usage))
+            ~ty:Rrd.Gauge
+            ~default:false
+            ~units:"mW" ()
+        | Gpumon_config.Temperature ->
+          let temperature = Nvml.device_get_temperature interface gpu.device in
+          Rrd.Host,
+          Ds.ds_make
+            ~name:("gpu_temperature_" ^ gpu.bus_id_escaped)
+            ~description:"Temperature of this GPU"
+            ~value:(Rrd.VT_Int64 (Int64.of_int temperature))
+            ~ty:Rrd.Gauge
+            ~default:false
+            ~units:"°C" ())
+      gpu.other_metrics
+  in
+  let utilisation_dss =
+    match gpu.utilisation_metrics with
+    | [] -> []
+    | metrics ->
+      let utilization =
+        Nvml.device_get_utilization_rates interface gpu.device in
+      List.map
+        (function
+          | Gpumon_config.Compute ->
+            Rrd.Host,
+            Ds.ds_make
+              ~name:("gpu_utilisation_compute_" ^ gpu.bus_id_escaped)
+              ~description:("Proportion of time over the past sample period during"^
+                            " which one or more kernels was executing on this GPU")
+              ~value:(Rrd.VT_Float ((float_of_int utilization.Nvml.gpu) /. 100.0))
+              ~ty:Rrd.Gauge
+              ~default:false
+              ~min:0.0
+              ~max:1.0
+              ~units:"(fraction)" ()
+          | Gpumon_config.MemoryIO ->
+            Rrd.Host,
+            Ds.ds_make
+              ~name:("gpu_utilisation_memory_io_" ^ gpu.bus_id_escaped)
+              ~description:("Proportion of time over the past sample period during"^
+                            " which global (device) memory was being read or written on this GPU")
+              ~value:(Rrd.VT_Float ((float_of_int utilization.Nvml.memory) /. 100.0))
+              ~ty:Rrd.Gauge
+              ~default:false
+              ~min:0.0
+              ~max:1.0
+              ~units:"(fraction)" ())
+        metrics
+  in
+  List.fold_left
+    (fun acc metrics -> List.rev_append metrics acc)
+    [] [memory_dss; other_dss; utilisation_dss]
 
 (** Generate datasources for all GPUs. *)
 let generate_all_gpu_dss interface gpus =
-	List.fold_left
-		(fun acc gpu ->
-			let dss = generate_gpu_dss interface gpu in
-			List.rev_append dss acc)
-		[] gpus
+  List.fold_left
+    (fun acc gpu ->
+       let dss = generate_gpu_dss interface gpu in
+       List.rev_append dss acc)
+    [] gpus
 
 (** Open and initialise an interface to the NVML library. Close the library if
  *  initialisation fails. *)
 let open_nvml_interface () =
-	let interface = Nvml.library_open () in
-	try
-		Nvml.init interface;
-		interface
-	with e ->
-		Nvml.library_close interface;
-		raise e
+  let interface = Nvml.library_open () in
+  try
+    Nvml.init interface;
+    interface
+  with e ->
+    Nvml.library_close interface;
+    raise e
 
 let open_nvml_interface_noexn () =
-	try Some (open_nvml_interface ())
-	with e ->
-		begin match e with
-			| Nvml.Library_not_loaded msg ->
-				Process.D.error "NVML interface not loaded: %s" msg
-			| Nvml.Symbol_not_loaded msg ->
-				Process.D.error "NVML missing expected symbol: %s" msg
-			| e ->
-				Process.D.error
-					"Caught unexpected error initialising NVML: %s"
-					(Printexc.to_string e)
-		end;
-		None
+  try Some (open_nvml_interface ())
+  with e ->
+    begin match e with
+      | Nvml.Library_not_loaded msg ->
+        Process.D.error "NVML interface not loaded: %s" msg
+      | Nvml.Symbol_not_loaded msg ->
+        Process.D.error "NVML missing expected symbol: %s" msg
+      | e ->
+        Process.D.error
+          "Caught unexpected error initialising NVML: %s"
+          (Printexc.to_string e)
+    end;
+    None
 
 (** Shutdown and close an interface to the NVML library. *)
 let close_nvml_interface interface =
-	Stdext.Pervasiveext.finally
-		(fun () -> Nvml.shutdown interface)
-		(fun () -> Nvml.library_close interface)
+  Stdext.Pervasiveext.finally
+    (fun () -> Nvml.shutdown interface)
+    (fun () -> Nvml.library_close interface)
 
 let start server =
-	let (_: Thread.t) = Thread.create (fun () ->
-		Xcp_service.serve_forever server
-	) () in
-	()
+  let (_: Thread.t) = Thread.create (fun () ->
+      Xcp_service.serve_forever server
+    ) () in
+  ()
 
 let handle_shutdown handler () =
-	Sys.set_signal Sys.sigterm (Sys.Signal_handle handler);
-	Sys.set_signal Sys.sigint  (Sys.Signal_handle handler);
-	Sys.set_signal Sys.sigpipe Sys.Signal_ignore
+  Sys.set_signal Sys.sigterm (Sys.Signal_handle handler);
+  Sys.set_signal Sys.sigint  (Sys.Signal_handle handler);
+  Sys.set_signal Sys.sigpipe Sys.Signal_ignore
 
 let () =
-	Process.initialise ();
-	let maybe_interface = open_nvml_interface_noexn () in
+  Process.initialise ();
+  let maybe_interface = open_nvml_interface_noexn () in
 
-	(* Define the new signal handler *)
-	let stop_handler signal =
-		let _ = match maybe_interface with
-		| Some interface -> close_nvml_interface interface
-		| None -> ()
-		in 
-		Process.D.info "Received signal %d: deregistering plugin %s..." signal plugin_name;
-		exit 0
-	in
-	(* gpumon idl server *)
-	let module Gpumon_server = Gpumon_server.Make(struct
-		let interface = maybe_interface
-	end) in
-	let module Server = Gpumon_interface.RPC_API(Idl.GenServerExn ()) in
-	let server = Xcp_service.make
-		~path:Gpumon_interface.xml_path
-		~queue_name:Gpumon_interface.queue_name
-		~rpc_fn:(Idl.server Server.implementation)
-		()
-	in
-	let _ = (handle_shutdown stop_handler (); start server) in
+  (* Define the new signal handler *)
+  let stop_handler signal =
+    let _ = match maybe_interface with
+      | Some interface -> close_nvml_interface interface
+      | None -> ()
+    in
+    Process.D.info "Received signal %d: deregistering plugin %s..." signal plugin_name;
+    exit 0
+  in
+  (* gpumon idl server *)
+  let module Gpumon_server = Gpumon_server.Make(struct
+      let interface = maybe_interface
+    end) in
+  let module Server = Gpumon_interface.RPC_API(Idl.GenServerExn ()) in
+  let server = Xcp_service.make
+      ~path:Gpumon_interface.xml_path
+      ~queue_name:Gpumon_interface.queue_name
+      ~rpc_fn:(Idl.server Server.implementation)
+      ()
+  in
+  let _ = (handle_shutdown stop_handler (); start server) in
 
-	(* gpumon rrdd interface *)
-	let rec rrdd_loop interface = 
-		try
-			let gpus = get_gpus interface in
-			(* Share one page per GPU - this is plenty for the six datasources per GPU
-			 * which we currently report. *)
-			let shared_page_count = List.length gpus in
-			Process.main_loop
-				~neg_shift:0.5
-				~target:(Reporter.Local shared_page_count)
-				~protocol:Rrd_interface.V2
-				~dss_f:(fun () -> generate_all_gpu_dss interface gpus)
-		with e -> begin
-			Process.D.error "Unexpected exception: %s" (Printexc.to_string e);
-			Thread.delay 5.0;
-			rrdd_loop interface
-		end
-	in
-	
-	match maybe_interface with
-	| Some interface -> begin
-		Process.D.info "Opened NVML interface";
-		rrdd_loop interface
-	end
-	| None ->
-		Process.D.info "Could not open NVML interface - sleeping forever";
-		while true do
-			Thread.delay 3600.0
-		done
+  (* gpumon rrdd interface *)
+  let rec rrdd_loop interface =
+    try
+      let gpus = get_gpus interface in
+      (* Share one page per GPU - this is plenty for the six datasources per GPU
+         			 * which we currently report. *)
+      let shared_page_count = List.length gpus in
+      Process.main_loop
+        ~neg_shift:0.5
+        ~target:(Reporter.Local shared_page_count)
+        ~protocol:Rrd_interface.V2
+        ~dss_f:(fun () -> generate_all_gpu_dss interface gpus)
+    with e -> begin
+        Process.D.error "Unexpected exception: %s" (Printexc.to_string e);
+        Thread.delay 5.0;
+        rrdd_loop interface
+      end
+  in
+
+  match maybe_interface with
+  | Some interface -> begin
+      Process.D.info "Opened NVML interface";
+      rrdd_loop interface
+    end
+  | None ->
+    Process.D.info "Could not open NVML interface - sleeping forever";
+    while true do
+      Thread.delay 3600.0
+    done

--- a/gpumon/gpumon_server.ml
+++ b/gpumon/gpumon_server.ml
@@ -31,7 +31,7 @@ module Make(I: Interface) = struct
       | Some interface -> interface
       | None -> raise Gpumon_interface.(Gpumon_error NvmlInterfaceNotAvailable)
 
-    let get_pgpu_metadata _ dbg pgpu_address =
+    let get_pgpu_metadata dbg pgpu_address =
       let this = "get_pgpu_metadata" in
       let interface = get_interface_exn () in
       try
@@ -58,7 +58,7 @@ module Make(I: Interface) = struct
       | Gpumon_interface.(Gpumon_error (NvmlFailure _)) as err -> raise err
       | err -> raise Gpumon_interface.(Gpumon_error (NvmlFailure (Printexc.to_string err)))
 
-    let get_vgpu_metadata _ dbg domid pgpu_address =
+    let get_vgpu_metadata dbg domid pgpu_address =
       let interface = get_interface_exn () in
       let domid'    = string_of_int domid  in
       try
@@ -68,7 +68,7 @@ module Make(I: Interface) = struct
       with err ->
         raise Gpumon_interface.(Gpumon_error (NvmlFailure (Printexc.to_string err)))
 
-    let get_pgpu_vgpu_compatibility x dbg pgpu_metadata vgpu_metadata =
+    let get_pgpu_vgpu_compatibility dbg pgpu_metadata vgpu_metadata =
       let interface = get_interface_exn () in
       let compatibility =
         try
@@ -118,11 +118,10 @@ module Make(I: Interface) = struct
         | _, _ -> Gpumon_interface.(Incompatible failures)
 
 
-    let get_pgpu_vm_compatibility x dbg pgpu_address domid pgpu_metadata =
+    let get_pgpu_vm_compatibility dbg pgpu_address domid pgpu_metadata =
       get_pgpu_vgpu_compatibility
-        x
         dbg
         pgpu_metadata
-        (get_vgpu_metadata x dbg domid pgpu_address)
+        (get_vgpu_metadata dbg domid pgpu_address)
   end
 end

--- a/gpumon/gpumon_server.ml
+++ b/gpumon/gpumon_server.ml
@@ -63,8 +63,8 @@ module Make(I: Interface) = struct
       let domid'    = string_of_int domid  in
       try
         Nvml.device_get_handle_by_pci_bus_id interface pgpu_address
-        |> fun device -> Nvml.get_vgpus_for_vm interface device domid'
-                         |> List.map (Nvml.get_vgpu_metadata interface)
+        |> (fun device -> Nvml.get_vgpus_for_vm interface device domid')
+        |> List.map (Nvml.get_vgpu_metadata interface)
       with err ->
         raise Gpumon_interface.(Gpumon_error (NvmlFailure (Printexc.to_string err)))
 

--- a/gpumon/gpumon_server.ml
+++ b/gpumon/gpumon_server.ml
@@ -22,14 +22,14 @@ module Make(I: Interface) = struct
   type context = unit
 
   module Nvidia = struct
-    
+
     let host_driver_supporting_migration = 390
     (** Smallest major version of the host driver that supports migration *)
 
-    let get_interface_exn () = 
-    match I.interface with
-    | Some interface -> interface
-    | None -> raise Gpumon_interface.(Gpumon_error NvmlInterfaceNotAvailable)
+    let get_interface_exn () =
+      match I.interface with
+      | Some interface -> interface
+      | None -> raise Gpumon_interface.(Gpumon_error NvmlInterfaceNotAvailable)
 
     let get_pgpu_metadata _ dbg pgpu_address =
       let this = "get_pgpu_metadata" in
@@ -51,12 +51,12 @@ module Make(I: Interface) = struct
           compat
         else
           let msg = Printf.sprintf
-            "%s: pGPU host driver version %d < %d does not support migration"
-            this major host_driver_supporting_migration in
+              "%s: pGPU host driver version %d < %d does not support migration"
+              this major host_driver_supporting_migration in
           raise Gpumon_interface.(Gpumon_error (NvmlFailure msg))
       with
-        | Gpumon_interface.(Gpumon_error (NvmlFailure _)) as err -> raise err
-        | err -> raise Gpumon_interface.(Gpumon_error (NvmlFailure (Printexc.to_string err)))
+      | Gpumon_interface.(Gpumon_error (NvmlFailure _)) as err -> raise err
+      | err -> raise Gpumon_interface.(Gpumon_error (NvmlFailure (Printexc.to_string err)))
 
     let get_vgpu_metadata _ dbg domid pgpu_address =
       let interface = get_interface_exn () in
@@ -64,7 +64,7 @@ module Make(I: Interface) = struct
       try
         Nvml.device_get_handle_by_pci_bus_id interface pgpu_address
         |> fun device -> Nvml.get_vgpus_for_vm interface device domid'
-        |> List.map (Nvml.get_vgpu_metadata interface)
+                         |> List.map (Nvml.get_vgpu_metadata interface)
       with err ->
         raise Gpumon_interface.(Gpumon_error (NvmlFailure (Printexc.to_string err)))
 

--- a/lib/gpumon_config.ml
+++ b/lib/gpumon_config.ml
@@ -12,172 +12,172 @@ let bind_map f items =
 
 (* Metrics which require calling nvmlDeviceGetMemoryInfo *)
 type memory_metric =
-	| Free
-	| Used
+  | Free
+  | Used
 
 (* Metrics which have their own NVML calls. *)
 type other_metric =
-	| PowerUsage
-	| Temperature
+  | PowerUsage
+  | Temperature
 
 (* Metrics which require calling nvmlDeviceGetUtilizationRates *)
 type utilisation_metric =
-	| Compute
-	| MemoryIO
+  | Compute
+  | MemoryIO
 
 type metric =
-	| Memory of memory_metric
-	| Utilisation of utilisation_metric
-	| Other of other_metric
+  | Memory of memory_metric
+  | Utilisation of utilisation_metric
+  | Other of other_metric
 
 let metric_of_string str =
-	match String.lowercase str with
-	| "memoryfree" -> Ok (Memory Free)
-	| "memoryused" -> Ok (Memory Used)
-	| "temperature" -> Ok (Other Temperature)
-	| "powerusage" -> Ok (Other PowerUsage)
-	| "compute" -> Ok (Utilisation Compute)
-	| "memoryio" -> Ok (Utilisation MemoryIO)
-	| _ -> Error (`Parse_failure str)
+  match String.lowercase str with
+  | "memoryfree" -> Ok (Memory Free)
+  | "memoryused" -> Ok (Memory Used)
+  | "temperature" -> Ok (Other Temperature)
+  | "powerusage" -> Ok (Other PowerUsage)
+  | "compute" -> Ok (Utilisation Compute)
+  | "memoryio" -> Ok (Utilisation MemoryIO)
+  | _ -> Error (`Parse_failure str)
 
 let string_of_metric = function
-	| Memory Free -> "memoryfree"
-	| Memory Used -> "memoryused"
-	| Other Temperature -> "temperature"
-	| Other PowerUsage -> "powerusage"
-	| Utilisation Compute -> "compute"
-	| Utilisation MemoryIO -> "memoryio"
+  | Memory Free -> "memoryfree"
+  | Memory Used -> "memoryused"
+  | Other Temperature -> "temperature"
+  | Other PowerUsage -> "powerusage"
+  | Utilisation Compute -> "compute"
+  | Utilisation MemoryIO -> "memoryio"
 
 let metric_of_rpc = function
-	| Rpc.String str -> metric_of_string str
-	| rpc -> Error (`Parse_failure (Rpc.to_string rpc))
+  | Rpc.String str -> metric_of_string str
+  | rpc -> Error (`Parse_failure (Rpc.to_string rpc))
 
 let metrics_of_rpc = function
-	| Rpc.Enum metrics_rpc -> bind_map metric_of_rpc metrics_rpc
-	| rpc -> Error (`Parse_failure (Rpc.to_string rpc))
+  | Rpc.Enum metrics_rpc -> bind_map metric_of_rpc metrics_rpc
+  | rpc -> Error (`Parse_failure (Rpc.to_string rpc))
 
 let rpc_of_metric metric = Rpc.String (string_of_metric metric)
 
 let rpc_of_metrics metrics = Rpc.Enum (List.map rpc_of_metric metrics)
 
 type 'a requirement =
-	| Match of 'a
-	| Any
+  | Match of 'a
+  | Any
 
 type device_type = {
-	device_id: int32;
-	subsystem_device_id: int32 requirement;
-	metrics: metric list;
+  device_id: int32;
+  subsystem_device_id: int32 requirement;
+  metrics: metric list;
 }
 
 type config = {
-	device_types: device_type list;
+  device_types: device_type list;
 }
 
 type config_version =
-	| V1
-	| V2
+  | V1
+  | V2
 
 let version_of_dict dict =
-	let version_key = "version" in
-	if List.mem_assoc version_key dict then begin
-		match List.assoc version_key dict with
-		| Rpc.String "2" -> Ok V2
-		| rpc -> Error (`Unknown_version (Jsonrpc.to_string rpc))
-	end else
-		Ok V1
+  let version_key = "version" in
+  if List.mem_assoc version_key dict then begin
+    match List.assoc version_key dict with
+    | Rpc.String "2" -> Ok V2
+    | rpc -> Error (`Unknown_version (Jsonrpc.to_string rpc))
+  end else
+    Ok V1
 
 let unbox_string = function
-	| Rpc.String str -> Ok str
-	| rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
+  | Rpc.String str -> Ok str
+  | rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
 
 let unbox_enum = function
-	| Rpc.Enum enum -> Ok enum
-	| rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
+  | Rpc.Enum enum -> Ok enum
+  | rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
 
 let lookup key dict =
-	try Ok (List.assoc key dict)
-	with Not_found -> Error (`Parse_failure (Rpc.Dict dict |> Jsonrpc.to_string))
+  try Ok (List.assoc key dict)
+  with Not_found -> Error (`Parse_failure (Rpc.Dict dict |> Jsonrpc.to_string))
 
 let id_of_string str =
-	try Ok (Scanf.sscanf str "%lx" (fun x -> x))
-	with Scanf.Scan_failure _ -> Error (`Parse_failure str)
+  try Ok (Scanf.sscanf str "%lx" (fun x -> x))
+  with Scanf.Scan_failure _ -> Error (`Parse_failure str)
 
 let of_v1_format dict =
-	bind_map
-		(fun (device_id_string, metrics_rpc) ->
-			(* Try to read the device ID. *)
-			(id_of_string device_id_string)
-			(* Try to read the list of metrics. *)
-			>>= (fun device_id ->
-				metrics_of_rpc metrics_rpc
-			(* Return the constructed device type.
-			 * n.b. The V1 format doesn't support specifying a subsystem device ID. *)
-			>>= (fun metrics ->
-				Ok {
-					device_id;
-					subsystem_device_id = Any;
-					metrics;
-				})))
-		dict
-	>>| (fun device_types -> {device_types})
+  bind_map
+    (fun (device_id_string, metrics_rpc) ->
+       (* Try to read the device ID. *)
+       (id_of_string device_id_string)
+       (* Try to read the list of metrics. *)
+       >>= (fun device_id ->
+           metrics_of_rpc metrics_rpc
+           (* Return the constructed device type.
+              			 * n.b. The V1 format doesn't support specifying a subsystem device ID. *)
+           >>= (fun metrics ->
+               Ok {
+                 device_id;
+                 subsystem_device_id = Any;
+                 metrics;
+               })))
+    dict
+  >>| (fun device_types -> {device_types})
 
 let device_type_of_v2_format = function
-	| Rpc.Dict dict -> begin
-		(* Try to read the device ID. *)
-		(lookup "device_id" dict >>= unbox_string >>= id_of_string)
-		(* Try to read the subsystem device ID. If it's not in the dictionary then
-		 * assume we don't need to match it. *)
-		>>= (fun device_id ->
-			(if List.mem_assoc "subsystem_device_id" dict
-			then
-				(List.assoc "subsystem_device_id" dict |> unbox_string >>= id_of_string)
-				>>= (fun id -> Ok (Match id))
-			else Ok Any)
-		(* Try to read the list of metrics. *)
-		>>= (fun subsystem_device_id ->
-			(lookup "metrics" dict >>= metrics_of_rpc)
-		(* Return the constructed device type. *)
-		>>= (fun metrics ->
-			Ok {
-				device_id;
-				subsystem_device_id;
-				metrics;
-			})))
-	end
-	| rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
+  | Rpc.Dict dict -> begin
+      (* Try to read the device ID. *)
+      (lookup "device_id" dict >>= unbox_string >>= id_of_string)
+      (* Try to read the subsystem device ID. If it's not in the dictionary then
+         		 * assume we don't need to match it. *)
+      >>= (fun device_id ->
+          (if List.mem_assoc "subsystem_device_id" dict
+           then
+             (List.assoc "subsystem_device_id" dict |> unbox_string >>= id_of_string)
+             >>= (fun id -> Ok (Match id))
+           else Ok Any)
+          (* Try to read the list of metrics. *)
+          >>= (fun subsystem_device_id ->
+              (lookup "metrics" dict >>= metrics_of_rpc)
+              (* Return the constructed device type. *)
+              >>= (fun metrics ->
+                  Ok {
+                    device_id;
+                    subsystem_device_id;
+                    metrics;
+                  })))
+    end
+  | rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
 
 let device_types_of_v2_format = function
-	| Rpc.Enum items -> bind_map device_type_of_v2_format items
-	| rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
+  | Rpc.Enum items -> bind_map device_type_of_v2_format items
+  | rpc -> Error (`Parse_failure (Jsonrpc.to_string rpc))
 
 let of_v2_format dict =
-	lookup "device_types" dict
-	>>= device_types_of_v2_format
-	>>= (fun device_types -> Ok {device_types})
+  lookup "device_types" dict
+  >>= device_types_of_v2_format
+  >>= (fun device_types -> Ok {device_types})
 
 let of_rpc = function
-	| Rpc.Dict dict ->
-		version_of_dict dict
-		>>= (function
-			| V1 -> of_v1_format dict
-			| V2 -> of_v2_format dict)
-	| _ -> Error (`Parse_failure "No top-level dictionary")
+  | Rpc.Dict dict ->
+    version_of_dict dict
+    >>= (function
+        | V1 -> of_v1_format dict
+        | V2 -> of_v2_format dict)
+  | _ -> Error (`Parse_failure "No top-level dictionary")
 
 let of_string data =
-	(try Ok (Jsonrpc.of_string data)
-	with e -> Error (`Parse_failure (Printexc.to_string e)))
-	>>= of_rpc
+  (try Ok (Jsonrpc.of_string data)
+   with e -> Error (`Parse_failure (Printexc.to_string e)))
+  >>= of_rpc
 
 let of_file path =
-	if Sys.file_exists path then Unixext.string_of_file path |> of_string
-	else Error `Does_not_exist
+  if Sys.file_exists path then Unixext.string_of_file path |> of_string
+  else Error `Does_not_exist
 
 let to_string config =
-	Rpc.Dict
-		(List.map
-			(fun {device_id; metrics} ->
-				Printf.sprintf "%04lx" device_id,
-				rpc_of_metrics metrics)
-			config.device_types)
-	|> Jsonrpc.to_string
+  Rpc.Dict
+    (List.map
+       (fun {device_id; metrics} ->
+          Printf.sprintf "%04lx" device_id,
+          rpc_of_metrics metrics)
+       config.device_types)
+  |> Jsonrpc.to_string

--- a/lib/gpumon_config.mli
+++ b/lib/gpumon_config.mli
@@ -1,48 +1,48 @@
 (* Metrics which require calling nvmlDeviceGetMemoryInfo *)
 type memory_metric =
-	| Free
-	| Used
+  | Free
+  | Used
 
 (* Metrics which have their own NVML calls. *)
 type other_metric =
-	| PowerUsage
-	| Temperature
+  | PowerUsage
+  | Temperature
 
 (* Metrics which require calling nvmlDeviceGetUtilizationRates *)
 type utilisation_metric =
-	| Compute
-	| MemoryIO
+  | Compute
+  | MemoryIO
 
 type metric =
-	| Memory of memory_metric
-	| Utilisation of utilisation_metric
-	| Other of other_metric
+  | Memory of memory_metric
+  | Utilisation of utilisation_metric
+  | Other of other_metric
 
 type 'a requirement =
-	| Match of 'a
-	| Any
+  | Match of 'a
+  | Any
 
 type device_type = {
-	device_id: int32;
-	subsystem_device_id: int32 requirement;
-	metrics: metric list;
+  device_id: int32;
+  subsystem_device_id: int32 requirement;
+  metrics: metric list;
 }
 
 type config = {
-	device_types: device_type list;
+  device_types: device_type list;
 }
 
 val of_string : string ->
-	(config, [
-		| `Parse_failure of string
-		| `Unknown_version of string
-	]) Rresult.result
+  (config, [
+      | `Parse_failure of string
+      | `Unknown_version of string
+    ]) Rresult.result
 
 val of_file : string ->
-	(config, [
-		| `Parse_failure of string
-		| `Unknown_version of string
-		| `Does_not_exist
-	]) Rresult.result
+  (config, [
+      | `Parse_failure of string
+      | `Unknown_version of string
+      | `Does_not_exist
+    ]) Rresult.result
 
 val to_string : config -> string

--- a/lib/nvml.ml
+++ b/lib/nvml.ml
@@ -6,27 +6,27 @@ type interface
 type device
 
 type enable_state =
-	| Disabled
-	| Enabled
+  | Disabled
+  | Enabled
 
 type memory_info = {
-	total: int64;
-	free: int64;
-	used: int64;
+  total: int64;
+  free: int64;
+  used: int64;
 }
 
 type pci_info = {
-	bus_id: string; (** domain:bus:device.function PCI identifier *)
-	domain: int32;
-	bus: int32;
-	device: int32;
-	pci_device_id: int32;
-	pci_subsystem_id: int32;
+  bus_id: string; (** domain:bus:device.function PCI identifier *)
+  domain: int32;
+  bus: int32;
+  device: int32;
+  pci_device_id: int32;
+  pci_subsystem_id: int32;
 }
 
 type utilization = {
-	gpu: int;
-	memory: int;
+  gpu: int;
+  memory: int;
 }
 
 type pgpu_metadata = string
@@ -42,9 +42,9 @@ type pgpu_compat_limit = None | HostDriver | GuestDriver | GPU | Other
 
 external library_open: unit -> interface = "stub_nvml_open"
 let library_open () =
-	Callback.register_exception "Library_not_loaded" (Library_not_loaded "");
-	Callback.register_exception "Symbol_not_loaded" (Symbol_not_loaded "");
-	library_open ();
+  Callback.register_exception "Library_not_loaded" (Library_not_loaded "");
+  Callback.register_exception "Symbol_not_loaded" (Symbol_not_loaded "");
+  library_open ();
 
 external library_close: interface -> unit = "stub_nvml_close"
 
@@ -53,54 +53,54 @@ external shutdown: interface -> unit = "stub_nvml_shutdown"
 
 external device_get_count: interface -> int = "stub_nvml_device_get_count"
 external device_get_handle_by_index: interface -> int -> device =
-	"stub_nvml_device_get_handle_by_index"
+  "stub_nvml_device_get_handle_by_index"
 external device_get_handle_by_pci_bus_id: interface -> string -> device =
-	"stub_nvml_device_get_handle_by_pci_bus_id"
+  "stub_nvml_device_get_handle_by_pci_bus_id"
 external device_get_memory_info: interface -> device -> memory_info =
-	"stub_nvml_device_get_memory_info"
+  "stub_nvml_device_get_memory_info"
 external device_get_pci_info: interface -> device -> pci_info =
-	"stub_nvml_device_get_pci_info"
+  "stub_nvml_device_get_pci_info"
 external device_get_temperature: interface -> device -> int =
-	"stub_nvml_device_get_temperature"
+  "stub_nvml_device_get_temperature"
 external device_get_power_usage: interface -> device -> int =
-	"stub_nvml_device_get_power_usage"
+  "stub_nvml_device_get_power_usage"
 external device_get_utilization_rates: interface -> device -> utilization =
-	"stub_nvml_device_get_utilization_rates"
+  "stub_nvml_device_get_utilization_rates"
 
 external device_set_persistence_mode: interface -> device -> enable_state ->
-	unit =
-	"stub_nvml_device_set_persistence_mode"
+  unit =
+  "stub_nvml_device_set_persistence_mode"
 
 external device_get_pgpu_metadata: interface -> device -> pgpu_metadata =
-	"stub_nvml_device_get_pgpu_metadata"
+  "stub_nvml_device_get_pgpu_metadata"
 external pgpu_metadata_get_pgpu_version: pgpu_metadata -> int =
-	"stub_pgpu_metadata_get_pgpu_version"
+  "stub_pgpu_metadata_get_pgpu_version"
 external pgpu_metadata_get_pgpu_revision: pgpu_metadata -> int =
-	"stub_pgpu_metadata_get_pgpu_revision"
+  "stub_pgpu_metadata_get_pgpu_revision"
 external pgpu_metadata_get_pgpu_host_driver_version: pgpu_metadata -> string =
-	"stub_pgpu_metadata_get_pgpu_host_driver_version"
+  "stub_pgpu_metadata_get_pgpu_host_driver_version"
 
 external device_get_active_vgpus: interface -> device -> vgpu_instance list = 
-	"stub_nvml_device_get_active_vgpus"
+  "stub_nvml_device_get_active_vgpus"
 external vgpu_instance_get_vm_domid: interface -> vgpu_instance -> vm_domid = 
-	"stub_nvml_vgpu_instance_get_vm_id"
+  "stub_nvml_vgpu_instance_get_vm_id"
 
 external get_vgpu_metadata: interface -> vgpu_instance -> vgpu_metadata =
-	"stub_nvml_get_vgpu_metadata"
+  "stub_nvml_get_vgpu_metadata"
 
 external get_pgpu_vgpu_compatibility: interface -> vgpu_metadata -> pgpu_metadata -> vgpu_compatibility_t =
-	"stub_nvml_get_pgpu_vgpu_compatibility"
+  "stub_nvml_get_pgpu_vgpu_compatibility"
 
 external vgpu_compat_get_vm_compat: vgpu_compatibility_t -> vm_compat list =
-	"stub_vgpu_compat_get_vm_compat"
+  "stub_vgpu_compat_get_vm_compat"
 external vgpu_compat_get_pgpu_compat_limit: vgpu_compatibility_t -> pgpu_compat_limit list =
-	"stub_vgpu_compat_get_pgpu_compat_limit"
+  "stub_vgpu_compat_get_pgpu_compat_limit"
 
 (* The functions below could raise any of the nvml errors raised from the stubs *)
 let get_vgpus_for_vm iface device vm_domid =
-	let vgpus = device_get_active_vgpus iface device in
-	let open Stdext.Listext in
-	List.filter_map (fun vgpu ->
-		match vgpu_instance_get_vm_domid iface vgpu with 
-		| domid when domid = vm_domid -> Some vgpu
-		| _ -> None) vgpus
+  let vgpus = device_get_active_vgpus iface device in
+  let open Stdext.Listext in
+  List.filter_map (fun vgpu ->
+      match vgpu_instance_get_vm_domid iface vgpu with 
+      | domid when domid = vm_domid -> Some vgpu
+      | _ -> None) vgpus

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -3,141 +3,141 @@ open OUnit
 let string_of_result =
   let open Rresult in
   function
-	| Error (`Parse_failure msg) -> Printf.sprintf "Parse_failure %s" msg
-	| Error (`Unknown_version version) ->
-		Printf.sprintf "Unknown_version %s" version
-	| Error `Does_not_exist -> "Does_not_exist"
-	| Ok config -> Printf.sprintf "Ok %s" (Gpumon_config.to_string config)
+  | Error (`Parse_failure msg) -> Printf.sprintf "Parse_failure %s" msg
+  | Error (`Unknown_version version) ->
+    Printf.sprintf "Unknown_version %s" version
+  | Error `Does_not_exist -> "Does_not_exist"
+  | Ok config -> Printf.sprintf "Ok %s" (Gpumon_config.to_string config)
 
 let test_file config_file expected_result =
-	let config_file_path = Filename.concat "test/data" config_file in
-	let actual_result = Gpumon_config.of_file config_file_path in
-	assert_equal ~msg:"Unexpected result from read_config_file"
-		~printer:string_of_result
-		expected_result actual_result
+  let config_file_path = Filename.concat "test/data" config_file in
+  let actual_result = Gpumon_config.of_file config_file_path in
+  assert_equal ~msg:"Unexpected result from read_config_file"
+    ~printer:string_of_result
+    expected_result actual_result
 
 let default_config =
-	let open Gpumon_config in
-	{
-		device_types = [
-			(* GRID K1 *)
-			{
-				device_id = 0x0ff2l;
-				subsystem_device_id = Any;
-				metrics = [
-					Memory Free;
-					Memory Used;
-					Other Temperature;
-					Other PowerUsage;
-					Utilisation Compute;
-					Utilisation MemoryIO;
-				];
-			};
-			(* GRID K2 *)
-			{
-				device_id = 0x11bfl;
-				subsystem_device_id = Any;
-				metrics = [
-					Memory Free;
-					Memory Used;
-					Other Temperature;
-					Other PowerUsage;
-					Utilisation Compute;
-					Utilisation MemoryIO;
-				];
-			};
-		];
-	}
+  let open Gpumon_config in
+  {
+    device_types = [
+      (* GRID K1 *)
+      {
+        device_id = 0x0ff2l;
+        subsystem_device_id = Any;
+        metrics = [
+          Memory Free;
+          Memory Used;
+          Other Temperature;
+          Other PowerUsage;
+          Utilisation Compute;
+          Utilisation MemoryIO;
+        ];
+      };
+      (* GRID K2 *)
+      {
+        device_id = 0x11bfl;
+        subsystem_device_id = Any;
+        metrics = [
+          Memory Free;
+          Memory Used;
+          Other Temperature;
+          Other PowerUsage;
+          Utilisation Compute;
+          Utilisation MemoryIO;
+        ];
+      };
+    ];
+  }
 
 let default_with_match_config =
-	let open Gpumon_config in
-	{
-		device_types = [
-			(* GRID K1 *)
-			{
-				device_id = 0x0ff2l;
-				subsystem_device_id = Match 0x1012l;
-				metrics = [
-					Memory Free;
-					Memory Used;
-					Other Temperature;
-					Other PowerUsage;
-					Utilisation Compute;
-					Utilisation MemoryIO;
-				];
-			};
-			(* GRID K2 *)
-			{
-				device_id = 0x11bfl;
-				subsystem_device_id = Match 0x100al;
-				metrics = [
-					Memory Free;
-					Memory Used;
-					Other Temperature;
-					Other PowerUsage;
-					Utilisation Compute;
-					Utilisation MemoryIO;
-				];
-			};
-		];
-	}
+  let open Gpumon_config in
+  {
+    device_types = [
+      (* GRID K1 *)
+      {
+        device_id = 0x0ff2l;
+        subsystem_device_id = Match 0x1012l;
+        metrics = [
+          Memory Free;
+          Memory Used;
+          Other Temperature;
+          Other PowerUsage;
+          Utilisation Compute;
+          Utilisation MemoryIO;
+        ];
+      };
+      (* GRID K2 *)
+      {
+        device_id = 0x11bfl;
+        subsystem_device_id = Match 0x100al;
+        metrics = [
+          Memory Free;
+          Memory Used;
+          Other Temperature;
+          Other PowerUsage;
+          Utilisation Compute;
+          Utilisation MemoryIO;
+        ];
+      };
+    ];
+  }
 
 let subsystem_device_id_config =
-	let open Gpumon_config in
-	{
-		device_types = [
-			{
-				device_id = 0x1234l;
-				subsystem_device_id = Match 0x5687l;
-				metrics = [
-					Memory Free;
-					Memory Used;
-				];
-			};
-		];
-	}
+  let open Gpumon_config in
+  {
+    device_types = [
+      {
+        device_id = 0x1234l;
+        subsystem_device_id = Match 0x5687l;
+        metrics = [
+          Memory Free;
+          Memory Used;
+        ];
+      };
+    ];
+  }
 
 let v2_mixed_config =
-	let open Gpumon_config in
-	{
-		device_types = [
-			{
-				device_id = 0x1234l;
-				subsystem_device_id = Any;
-				metrics = [
-					Other Temperature;
-					Other PowerUsage;
-				];
-			};
-			{
-				device_id = 0x5678l;
-				subsystem_device_id = Match 0x9abcl;
-				metrics = [
-					Utilisation Compute;
-					Utilisation MemoryIO;
-				];
-			};
-		];
-	}
+  let open Gpumon_config in
+  {
+    device_types = [
+      {
+        device_id = 0x1234l;
+        subsystem_device_id = Any;
+        metrics = [
+          Other Temperature;
+          Other PowerUsage;
+        ];
+      };
+      {
+        device_id = 0x5678l;
+        subsystem_device_id = Match 0x9abcl;
+        metrics = [
+          Utilisation Compute;
+          Utilisation MemoryIO;
+        ];
+      };
+    ];
+  }
 
 let tests =
-	let open Gpumon_config in
+  let open Gpumon_config in
   let open Rresult in
-	[
-		"test_does_not_exist.conf", Error `Does_not_exist;
-		"test_unknown_version.conf", Error (`Unknown_version "\"4\"");
-		"test_v1_minimal.conf", Ok {device_types = []};
-		"test_v2_minimal.conf", Ok {device_types = []};
-		"test_v1_default.conf", Ok default_config;
-		"test_v2_default.conf", Ok default_config;
-		"test_v2_default_with_match.conf", Ok default_with_match_config;
-		"test_v2_with_subsystem_device_id.conf", Ok subsystem_device_id_config;
-		"test_v2_mixed.conf", Ok v2_mixed_config;
-	]
+  [
+    "test_does_not_exist.conf", Error `Does_not_exist;
+    "test_unknown_version.conf", Error (`Unknown_version "\"4\"");
+    "test_v1_minimal.conf", Ok {device_types = []};
+    "test_v2_minimal.conf", Ok {device_types = []};
+    "test_v1_default.conf", Ok default_config;
+    "test_v2_default.conf", Ok default_config;
+    "test_v2_default_with_match.conf", Ok default_with_match_config;
+    "test_v2_with_subsystem_device_id.conf", Ok subsystem_device_id_config;
+    "test_v2_mixed.conf", Ok v2_mixed_config;
+  ]
 
 let test =
-	"test_config" >:::
-		(List.map
-			(fun (config_file, expected_result) ->
-				config_file >:: (fun () ->  test_file config_file expected_result))
-			tests)
+  "test_config" >:::
+  (List.map
+     (fun (config_file, expected_result) ->
+        config_file >:: (fun () ->  test_file config_file expected_result))
+     tests)

--- a/test/test_main.ml
+++ b/test/test_main.ml
@@ -1,10 +1,10 @@
 open OUnit
 
 let base_suite =
-	"base_suite" >:::
-		[
-			Test_config.test;
-		]
+  "base_suite" >:::
+  [
+    Test_config.test;
+  ]
 
 let () =
-	OUnit2.run_test_tt_main (OUnit.ounit2_of_ounit1 base_suite)
+  OUnit2.run_test_tt_main (OUnit.ounit2_of_ounit1 base_suite)


### PR DESCRIPTION
This is the final of three PRs to port GPU monitoring daemon gpumon to use PPX-based RPCs.

1. [Gpumon interface port](https://github.com/xapi-project/xcp-idl/pull/196)
2. [Update Xapi](https://github.com/xapi-project/xen-api/pull/3418)
3. [this]