### PR TITLE
CA-283715: Bind API call declarations to implementations

### DIFF
--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -1,7 +1,16 @@
+
+module type IMPLEMENTATION = sig
+  open Gpumon_interface
+
+  val get_pgpu_metadata           : debug_info -> pgpu_address         -> nvidia_pgpu_metadata
+  val get_vgpu_metadata           : debug_info -> domid                -> pgpu_address              -> nvidia_vgpu_metadata list
+  val get_pgpu_vm_compatibility   : debug_info -> pgpu_address         -> domid                     -> nvidia_pgpu_metadata -> compatibility
+  val get_pgpu_vgpu_compatibility : debug_info -> nvidia_pgpu_metadata -> nvidia_vgpu_metadata list -> compatibility
+end
+
 open Rrdd_plugin
 
 let plugin_name = "xcp-rrdd-gpumon"
-
 module Process = Process(struct let name = plugin_name end)
 
 let nvidia_vendor_id = 0x10del
@@ -280,8 +289,10 @@ let close_nvml_interface interface =
     (fun () -> Nvml.shutdown interface)
     (fun () -> Nvml.library_close interface)
 
+(* start server *)
 let start server =
-  let (_: Thread.t) = Thread.create (fun () ->
+  let (_: Thread.t) = Thread.create
+    (fun () ->
       Xcp_service.serve_forever server
     ) () in
   ()
@@ -290,6 +301,21 @@ let handle_shutdown handler () =
   Sys.set_signal Sys.sigterm (Sys.Signal_handle handler);
   Sys.set_signal Sys.sigint  (Sys.Signal_handle handler);
   Sys.set_signal Sys.sigpipe Sys.Signal_ignore
+
+
+(* PPX-based server generation *)
+module Server = Gpumon_interface.RPC_API(Idl.GenServerExn ())
+
+(* Provide server API calls *)
+module Make(Impl : IMPLEMENTATION) = struct
+
+  (* bind server method declarations to implementations *)
+  let bind () =
+    Server.Nvidia.get_pgpu_metadata           Impl.get_pgpu_metadata           ;
+    Server.Nvidia.get_vgpu_metadata           Impl.get_vgpu_metadata           ;
+    Server.Nvidia.get_pgpu_vgpu_compatibility Impl.get_pgpu_vgpu_compatibility ;
+    Server.Nvidia.get_pgpu_vm_compatibility   Impl.get_pgpu_vm_compatibility
+end
 
 let () =
   Process.initialise ();
@@ -304,11 +330,13 @@ let () =
     Process.D.info "Received signal %d: deregistering plugin %s..." signal plugin_name;
     exit 0
   in
-  (* gpumon idl server *)
   let module Gpumon_server = Gpumon_server.Make(struct
       let interface = maybe_interface
     end) in
-  let module Server = Gpumon_interface.RPC_API(Idl.GenServerExn ()) in
+  (* create daemon module to bind server call declarations to implementations *)
+  let module Daemon = Make(Gpumon_server.Nvidia) in
+  Daemon.bind ();
+
   let server = Xcp_service.make
       ~path:Gpumon_interface.xml_path
       ~queue_name:Gpumon_interface.queue_name


### PR DESCRIPTION
vGPU migration issues were caused by RPC calls to gpumon failing, due to a lack of bindings for server calls.
This commit adds an implementation module type, which the Gpumon_server.Nvidia module satisfies, and binds the implementation to the generated server.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>