### PR TITLE
 CA-283715: Bind API call declarations to implementations 

### DIFF
--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -1,13 +1,4 @@
 
-module type IMPLEMENTATION = sig
-  open Gpumon_interface
-
-  val get_pgpu_metadata           : debug_info -> pgpu_address         -> nvidia_pgpu_metadata
-  val get_vgpu_metadata           : debug_info -> domid                -> pgpu_address              -> nvidia_vgpu_metadata list
-  val get_pgpu_vm_compatibility   : debug_info -> pgpu_address         -> domid                     -> nvidia_pgpu_metadata -> compatibility
-  val get_pgpu_vgpu_compatibility : debug_info -> nvidia_pgpu_metadata -> nvidia_vgpu_metadata list -> compatibility
-end
-
 open Rrdd_plugin
 
 let plugin_name = "xcp-rrdd-gpumon"
@@ -306,14 +297,14 @@ let handle_shutdown handler () =
 module Server = Gpumon_interface.RPC_API(Idl.GenServerExn ())
 
 (* Provide server API calls *)
-module Make(Impl : IMPLEMENTATION) = struct
+module Make(Impl : Gpumon_server.IMPLEMENTATION) = struct
 
   (* bind server method declarations to implementations *)
   let bind () =
-    Server.Nvidia.get_pgpu_metadata           Impl.get_pgpu_metadata           ;
-    Server.Nvidia.get_vgpu_metadata           Impl.get_vgpu_metadata           ;
-    Server.Nvidia.get_pgpu_vgpu_compatibility Impl.get_pgpu_vgpu_compatibility ;
-    Server.Nvidia.get_pgpu_vm_compatibility   Impl.get_pgpu_vm_compatibility
+    Server.Nvidia.get_pgpu_metadata           Impl.Nvidia.get_pgpu_metadata           ;
+    Server.Nvidia.get_vgpu_metadata           Impl.Nvidia.get_vgpu_metadata           ;
+    Server.Nvidia.get_pgpu_vgpu_compatibility Impl.Nvidia.get_pgpu_vgpu_compatibility ;
+    Server.Nvidia.get_pgpu_vm_compatibility   Impl.Nvidia.get_pgpu_vm_compatibility
 end
 
 let () =
@@ -333,7 +324,7 @@ let () =
       let interface = maybe_interface
     end) in
   (* create daemon module to bind server call declarations to implementations *)
-  let module Daemon = Make(Gpumon_server.Nvidia) in
+  let module Daemon = Make(Gpumon_server) in
   Daemon.bind ();
 
   let server = Xcp_service.make

--- a/gpumon/gpumon_server.ml
+++ b/gpumon/gpumon_server.ml
@@ -11,11 +11,25 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
+
+module type IMPLEMENTATION = sig
+  open Gpumon_interface
+  
+  module Nvidia: sig
+    val get_pgpu_metadata           : debug_info -> pgpu_address         -> nvidia_pgpu_metadata
+    val get_vgpu_metadata           : debug_info -> domid                -> pgpu_address              -> nvidia_vgpu_metadata list
+    val get_pgpu_vm_compatibility   : debug_info -> pgpu_address         -> domid                     -> nvidia_pgpu_metadata -> compatibility
+    val get_pgpu_vgpu_compatibility : debug_info -> nvidia_pgpu_metadata -> nvidia_vgpu_metadata list -> compatibility
+  end
+end
+
+
+
 module type Interface = sig
   val interface: Nvml.interface option
 end
 
-module Make(I: Interface) = struct
+module Make(I: Interface):IMPLEMENTATION = struct
   module D = Debug.Make(struct let name = Gpumon_interface.service_name end)
   open D
 


### PR DESCRIPTION
This supersedes https://github.com/xenserver/gpumon/pull/31

The `Gpumon_server` was missing the rpc call bindings, preventing any communication with xapi.