### PR TITLE
CP-33121: Remove direct Stdext usages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: c
-sudo: required
-service: docker
+services: docker
+os: linux
+dist: xenial
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+  - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
+  - source xs-opam-ci.env
   - cp  mocks/mock.ml lib/nvml.ml
   - cp  mocks/mock.c  stubs/nvml_stubs.c
 script: bash -ex .travis-docker.sh
@@ -10,6 +13,3 @@ env:
   global:
     - PACKAGE=gpumon
     - PINS="gpumon:."
-    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
-  matrix:
-    - DISTRO="debian-9-ocaml-4.07"

--- a/gpumon.opam
+++ b/gpumon.opam
@@ -1,22 +1,21 @@
 opam-version: "2.0"
+synopsis: "The XenServer GPU monitoring daemon"
 maintainer: "xen-api@lists.xen.org"
-authors: [ "John Else" ]
+authors: "John Else"
 homepage: "https://github.com/xenserver/gpumon"
 bug-reports: "https://github.com/xenserver/gpumon/issues"
+depends: [
+  "base-threads"
+  "ounit" {with-test}
+  "rresult"
+  "rrdd-plugin"
+  "xapi-idl"
+  "xapi-stdext-pervasives"
+  "xapi-stdext-std"
+  "xapi-stdext-unix"
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-depends: [
-  "base-threads"
-  "ounit"
-  "result"
-  "rrdd-plugin"
-  "stdext"
-  "xapi-idl"
-]
 dev-repo: "git://github.com/xenserver/gpumon"
-synopsis: "The XenServer GPU monitoring daemon"
-
-
-

--- a/gpumon/dune
+++ b/gpumon/dune
@@ -1,6 +1,13 @@
-
 (executable
  (name gpumon)
  (public_name gpumon)
- (libraries threads rrdd-plugin xapi-idl.gpumon gpumon_lib))
-
+ (libraries
+   gpumon_lib
+   rrdd-plugin
+   threads
+   xapi-idl.gpumon
+   xapi-stdext-pervasives
+   xapi-stdext-std
+   xapi-stdext-unix
+ )
+)

--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -90,7 +90,6 @@ let nvidia_config_path = "/usr/share/nvidia/monitoring.conf"
  *  See perf-tools.hg/scripts/monitoring.conf.example for an example of the
  *  expected config file format. *)
 let load_config () =
-  let open Rresult in
   match Gpumon_config.of_file nvidia_config_path with
   | Ok config -> [nvidia_vendor_id, config]
   | Error `Does_not_exist ->
@@ -118,7 +117,7 @@ type gpu = {
 (* Adding colons to datasource names confuses RRD parsers, so replace all
  * colons with "/" *)
 let escape_bus_id bus_id =
-  String.concat "/" (Stdext.Xstringext.String.split ':' bus_id)
+  String.concat "/" (String.split_on_char ':' bus_id)
 
 (** Get the list of devices recognised by NVML. *)
 let get_gpus interface =
@@ -277,7 +276,7 @@ let open_nvml_interface_noexn () =
 
 (** Shutdown and close an interface to the NVML library. *)
 let close_nvml_interface interface =
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () -> Nvml.shutdown interface)
     (fun () -> Nvml.library_close interface)
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name gpumon_lib)
   (wrapped false)
-  (libraries result stdext nvml_stubs))
+  (libraries nvml_stubs rresult xapi-stdext-unix))

--- a/lib/gpumon_config.ml
+++ b/lib/gpumon_config.ml
@@ -1,5 +1,5 @@
-open Stdext
-open Rresult
+open Rresult.R.Infix
+module Unixext = Xapi_stdext_unix.Unixext
 
 (** Like List.map, but will return an Error if and when f returns an Error. *)
 let bind_map f items =

--- a/lib/gpumon_config.mli
+++ b/lib/gpumon_config.mli
@@ -36,13 +36,13 @@ val of_string : string ->
   (config, [
       | `Parse_failure of string
       | `Unknown_version of string
-    ]) Rresult.result
+    ]) result
 
 val of_file : string ->
   (config, [
       | `Parse_failure of string
       | `Unknown_version of string
       | `Does_not_exist
-    ]) Rresult.result
+    ]) result
 
 val to_string : config -> string

--- a/lib/nvml.ml
+++ b/lib/nvml.ml
@@ -81,11 +81,11 @@ external pgpu_metadata_get_pgpu_revision: pgpu_metadata -> int =
 external pgpu_metadata_get_pgpu_host_driver_version: pgpu_metadata -> string =
   "stub_pgpu_metadata_get_pgpu_host_driver_version"
 
-external device_get_active_vgpus: interface -> device -> vgpu_instance list = 
+external device_get_active_vgpus: interface -> device -> vgpu_instance list =
   "stub_nvml_device_get_active_vgpus"
-external vgpu_instance_get_vm_domid: interface -> vgpu_instance -> vm_domid = 
+external vgpu_instance_get_vm_domid: interface -> vgpu_instance -> vm_domid =
   "stub_nvml_vgpu_instance_get_vm_id"
-external vgpu_instance_get_vgpu_uuid: interface -> vgpu_instance -> vgpu_uuid = 
+external vgpu_instance_get_vgpu_uuid: interface -> vgpu_instance -> vgpu_uuid =
   "stub_nvml_vgpu_instance_get_vgpu_uuid"
 
 external get_vgpu_metadata: interface -> vgpu_instance -> vgpu_metadata =
@@ -102,15 +102,13 @@ external vgpu_compat_get_pgpu_compat_limit: vgpu_compatibility_t -> pgpu_compat_
 (* The functions below could raise any of the nvml errors raised from the stubs *)
 let get_vgpus_for_vm iface device vm_domid =
   let vgpus = device_get_active_vgpus iface device in
-  let open Stdext.Listext in
   List.filter_map (fun vgpu ->
-      match vgpu_instance_get_vm_domid iface vgpu with 
+      match vgpu_instance_get_vm_domid iface vgpu with
       | domid when domid = vm_domid -> Some vgpu
       | _ -> None) vgpus
 
 let get_vgpu_for_uuid iface vgpu_uuid vgpus =
-  let open Stdext.Listext in
   List.filter_map (fun vgpu ->
-      match vgpu_instance_get_vgpu_uuid iface vgpu with 
+      match vgpu_instance_get_vgpu_uuid iface vgpu with
       | uuid when uuid = vgpu_uuid -> Some vgpu
       | _ -> None) vgpus

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -1,7 +1,6 @@
 open OUnit
 
 let string_of_result =
-  let open Rresult in
   function
   | Error (`Parse_failure msg) -> Printf.sprintf "Parse_failure %s" msg
   | Error (`Unknown_version version) ->
@@ -122,7 +121,6 @@ let v2_mixed_config =
 
 let tests =
   let open Gpumon_config in
-  let open Rresult in
   [
     "test_does_not_exist.conf", Error `Does_not_exist;
     "test_unknown_version.conf", Error (`Unknown_version "\"4\"");


### PR DESCRIPTION
Cleans up the opam and dune metadata; and the travis configuration.

in `gpumon/gpumon_server.ml` I tool the liberty to the filter and map at the same time to avoid using failwith.