### PR TITLE
CP-37861 - don't include nvml_grid.h

### DIFF
--- a/stubs/nvml_stubs.c
+++ b/stubs/nvml_stubs.c
@@ -1,7 +1,6 @@
 #include <dlfcn.h>
 
 #include <nvml.h>
-#include <nvml_grid.h>
 
 #include <string.h>
 


### PR DESCRIPTION
Header file nvml_grid.h is just a symlink to nvml.h and thus redundant.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>