### PR TITLE
CP-33044 Introduce NVML.{attach,detach} RPC calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test:
 
 format:
 	$(DUNE) build @fmt --auto-promote
+	git ls-files '**/*.[ch]' | xargs -n1 indent -nut -kr
 
 mock:
 	cp mocks/mock.ml lib/nvml.ml

--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -57,7 +57,7 @@ let categorise_metrics =
           (memory_metrics, x :: other_metrics, utilisation_metrics)
       | Gpumon_config.Utilisation x ->
           (memory_metrics, other_metrics, x :: utilisation_metrics)
-      )
+    )
     ([], [], [])
 
 (** NVML returns the PCI ID and PCI subsystem ID as int32s, where the most
@@ -88,7 +88,7 @@ let get_required_metrics config pci_info =
               id = subsystem_device_id
           | Any ->
               true
-          )
+        )
         vendor_config.device_types
     in
     Some (categorise_metrics device.metrics)
@@ -269,7 +269,7 @@ let generate_all_gpu_dss interface gpus =
     (fun acc gpu ->
       let dss = generate_gpu_dss interface gpu in
       List.rev_append dss acc
-      )
+    )
     [] gpus
 
 (** Open and initialise an interface to the NVML library. Close the library if

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name gpumon_lib)
  (wrapped false)
- (libraries nvml_stubs rresult xapi-stdext-unix))
+ (libraries nvml_stubs xapi-idl rresult xapi-stdext-unix))

--- a/lib/gpumon_config.ml
+++ b/lib/gpumon_config.ml
@@ -127,7 +127,7 @@ let of_v1_format dict =
          			 * n.b. The V1 format doesn't support specifying a subsystem device ID. *)
       >>=
       fun metrics -> Ok {device_id; subsystem_device_id= Any; metrics}
-      )
+    )
     dict
   >>| fun device_types -> {device_types}
 
@@ -191,7 +191,7 @@ let to_string config =
     (List.map
        (fun {device_id; metrics; _} ->
          (Printf.sprintf "%04lx" device_id, rpc_of_metrics metrics)
-         )
+       )
        config.device_types
     )
   |> Jsonrpc.to_string

--- a/lib/nvml.ml
+++ b/lib/nvml.ml
@@ -1,3 +1,5 @@
+module D = Debug.Make (struct let name = __MODULE__ end)
+
 exception Library_not_loaded of string
 
 exception Symbol_not_loaded of string
@@ -135,3 +137,60 @@ let get_vgpu_for_uuid iface vgpu_uuid vgpus =
           None
     )
     vgpus
+
+module NVML : sig
+  val attach : unit -> unit
+
+  val detach : unit -> unit
+
+  val is_attached : unit -> bool
+
+  val get : unit -> interface option
+end = struct
+  let interface = ref (None : interface option)
+
+  let mx = Mutex.create ()
+
+  let finally = Xapi_stdext_pervasives.Pervasiveext.finally
+
+  let with_mutex mx f =
+    Mutex.lock mx ;
+    finally f (fun () -> Mutex.unlock mx)
+
+  let open_nvml_interface () =
+    let interface = library_open () in
+    try init interface ; interface with e -> library_close interface ; raise e
+
+  let get () = !interface
+
+  let attach () =
+    with_mutex mx @@ fun () ->
+    match !interface with
+    | Some _ ->
+        D.warn "Nvml library attach: library already attached"
+    | None -> (
+      match open_nvml_interface () with
+      | i ->
+          interface := Some i ;
+          D.info "Nvml library attach: success"
+      | exception e ->
+          interface := None ;
+          D.warn "Nvml library attach: failure: %s" (Printexc.to_string e)
+    )
+
+  let detach () =
+    with_mutex mx @@ fun () ->
+    match !interface with
+    | None ->
+        D.warn "Nvml library detach: not library attached"
+    | Some intf ->
+        D.info "Nvml library detach: detaching" ;
+        finally
+          (fun () -> shutdown intf)
+          (fun () ->
+            interface := None ;
+            library_close intf
+          )
+
+  let is_attached () = match !interface with None -> false | Some _ -> true
+end

--- a/lib/nvml.ml
+++ b/lib/nvml.ml
@@ -122,7 +122,7 @@ let get_vgpus_for_vm iface device vm_domid =
           Some vgpu
       | _ ->
           None
-      )
+    )
     vgpus
 
 let get_vgpu_for_uuid iface vgpu_uuid vgpus =
@@ -133,5 +133,5 @@ let get_vgpu_for_uuid iface vgpu_uuid vgpus =
           Some vgpu
       | _ ->
           None
-      )
+    )
     vgpus

--- a/mocks/mock.ml
+++ b/mocks/mock.ml
@@ -100,3 +100,13 @@ let vgpu_compat_get_pgpu_compat_limit _vgpu_compatibility_t = []
 let get_vgpus_for_vm _iface _device _vm_domid = []
 
 let get_vgpu_for_uuid _iface _vgpu_uuid _vgpus = []
+
+module NVML = struct
+  let attach () = ()
+
+  let detach () = ()
+
+  let is_attached () = true
+
+  let get () : interface option = None
+end

--- a/stubs/nvml_stubs.c
+++ b/stubs/nvml_stubs.c
@@ -15,31 +15,45 @@
 #define STR(x) _STR(x)
 
 typedef struct nvmlInterface {
-    void* handle;
-    char* (*errorString)(nvmlReturn_t);
-    nvmlReturn_t (*init)(void);
-    nvmlReturn_t (*shutdown)(void);
-    nvmlReturn_t (*deviceGetCount)(unsigned int*);
-    nvmlReturn_t (*deviceGetHandleByIndex)(unsigned int, nvmlDevice_t*);
-    nvmlReturn_t (*deviceGetHandleByPciBusId)(const char*, nvmlDevice_t*);
-    nvmlReturn_t (*deviceGetMemoryInfo)(nvmlDevice_t, nvmlMemory_t*);
-    nvmlReturn_t (*deviceGetPciInfo)(nvmlDevice_t, nvmlPciInfo_t*);
-    nvmlReturn_t (*deviceGetTemperature)
-        (nvmlDevice_t, nvmlTemperatureSensors_t, unsigned int*);
-    nvmlReturn_t (*deviceGetPowerUsage)(nvmlDevice_t, unsigned int*);
-    nvmlReturn_t (*deviceGetUtilizationRates)(nvmlDevice_t, nvmlUtilization_t*);
+    void *handle;
+    char *(*errorString)(nvmlReturn_t);
+     nvmlReturn_t(*init) (void);
+     nvmlReturn_t(*shutdown) (void);
+     nvmlReturn_t(*deviceGetCount) (unsigned int *);
+     nvmlReturn_t(*deviceGetHandleByIndex) (unsigned int, nvmlDevice_t *);
+     nvmlReturn_t(*deviceGetHandleByPciBusId) (const char *,
+                                               nvmlDevice_t *);
+     nvmlReturn_t(*deviceGetMemoryInfo) (nvmlDevice_t, nvmlMemory_t *);
+     nvmlReturn_t(*deviceGetPciInfo) (nvmlDevice_t, nvmlPciInfo_t *);
+     nvmlReturn_t(*deviceGetTemperature)
+     (nvmlDevice_t, nvmlTemperatureSensors_t, unsigned int *);
+     nvmlReturn_t(*deviceGetPowerUsage) (nvmlDevice_t, unsigned int *);
+     nvmlReturn_t(*deviceGetUtilizationRates) (nvmlDevice_t,
+                                               nvmlUtilization_t *);
 
-    nvmlReturn_t (*deviceSetPersistenceMode)(nvmlDevice_t, nvmlEnableState_t);
-    
-    nvmlReturn_t (*deviceGetVgpuMetadata)(nvmlDevice_t, nvmlVgpuPgpuMetadata_t*, unsigned int*);
-    nvmlReturn_t (*vgpuInstanceGetMetadata)(nvmlVgpuInstance_t, nvmlVgpuMetadata_t*, unsigned int*);
-    nvmlReturn_t (*deviceGetActiveVgpus)(nvmlDevice_t, unsigned int*, nvmlVgpuInstance_t*);
-    nvmlReturn_t (*vgpuInstanceGetVmID)(nvmlVgpuInstance_t, char*, unsigned int, nvmlVgpuVmIdType_t*);
-    nvmlReturn_t (*vgpuInstanceGetUUID)(nvmlVgpuInstance_t, char*, unsigned int);
-    nvmlReturn_t (*getVgpuCompatibility)(nvmlVgpuMetadata_t*, nvmlVgpuPgpuMetadata_t*, nvmlVgpuPgpuCompatibility_t*);
+     nvmlReturn_t(*deviceSetPersistenceMode) (nvmlDevice_t,
+                                              nvmlEnableState_t);
+
+     nvmlReturn_t(*deviceGetVgpuMetadata) (nvmlDevice_t,
+                                           nvmlVgpuPgpuMetadata_t *,
+                                           unsigned int *);
+     nvmlReturn_t(*vgpuInstanceGetMetadata) (nvmlVgpuInstance_t,
+                                             nvmlVgpuMetadata_t *,
+                                             unsigned int *);
+     nvmlReturn_t(*deviceGetActiveVgpus) (nvmlDevice_t, unsigned int *,
+                                          nvmlVgpuInstance_t *);
+     nvmlReturn_t(*vgpuInstanceGetVmID) (nvmlVgpuInstance_t, char *,
+                                         unsigned int,
+                                         nvmlVgpuVmIdType_t *);
+     nvmlReturn_t(*vgpuInstanceGetUUID) (nvmlVgpuInstance_t, char *,
+                                         unsigned int);
+     nvmlReturn_t(*getVgpuCompatibility) (nvmlVgpuMetadata_t *,
+                                          nvmlVgpuPgpuMetadata_t *,
+                                          nvmlVgpuPgpuCompatibility_t *);
 } nvmlInterface;
 
-CAMLprim value stub_nvml_open(value unit) {
+CAMLprim value stub_nvml_open(value unit)
+{
     CAMLparam1(unit);
     CAMLlocal1(ml_interface);
 
@@ -57,267 +71,252 @@ CAMLprim value stub_nvml_open(value unit) {
         exn = caml_named_value("Library_not_loaded");
         if (exn) {
             caml_raise_with_string(*exn, dlerror());
-        }
-        else {
+        } else {
             caml_failwith(dlerror());
         }
     }
-
     // Load nvmlErrorString.
-    interface->errorString = dlsym(interface->handle, STR(nvmlErrorString));
+    interface->errorString =
+        dlsym(interface->handle, STR(nvmlErrorString));
     if (!interface->errorString) {
         goto SymbolError;
     }
-
     // Load nvmlInit.
     interface->init = dlsym(interface->handle, STR(nvmlInit));
     if (!interface->init) {
         goto SymbolError;
     }
-
     // Load nvmlShutdown.
     interface->shutdown = dlsym(interface->handle, STR(nvmlShutdown));
     if (!interface->shutdown) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetCount.
-    interface->deviceGetCount = dlsym(interface->handle, STR(nvmlDeviceGetCount));
+    interface->deviceGetCount =
+        dlsym(interface->handle, STR(nvmlDeviceGetCount));
     if (!interface->deviceGetCount) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetHandleByIndex.
     interface->deviceGetHandleByIndex =
         dlsym(interface->handle, STR(nvmlDeviceGetHandleByIndex));
-    if(!interface->deviceGetHandleByIndex) {
+    if (!interface->deviceGetHandleByIndex) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetHandleByPciBusId
     interface->deviceGetHandleByPciBusId =
         dlsym(interface->handle, STR(nvmlDeviceGetHandleByPciBusId));
-    if(!interface->deviceGetHandleByPciBusId) {
+    if (!interface->deviceGetHandleByPciBusId) {
         goto SymbolError;
     }
-
 
     // Load nvmlDeviceGetMemoryInfo.
     interface->deviceGetMemoryInfo =
         dlsym(interface->handle, STR(nvmlDeviceGetMemoryInfo));
-    if(!interface->deviceGetMemoryInfo) {
+    if (!interface->deviceGetMemoryInfo) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetPciInfo.
     interface->deviceGetPciInfo =
         dlsym(interface->handle, STR(nvmlDeviceGetPciInfo));
-    if(!interface->deviceGetPciInfo) {
+    if (!interface->deviceGetPciInfo) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetTemperature.
     interface->deviceGetTemperature =
         dlsym(interface->handle, STR(nvmlDeviceGetTemperature));
-    if(!interface->deviceGetTemperature) {
+    if (!interface->deviceGetTemperature) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetPowerUsage.
     interface->deviceGetPowerUsage =
         dlsym(interface->handle, STR(nvmlDeviceGetPowerUsage));
-    if(!interface->deviceGetPowerUsage) {
+    if (!interface->deviceGetPowerUsage) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetUtilizationRates.
     interface->deviceGetUtilizationRates =
         dlsym(interface->handle, STR(nvmlDeviceGetUtilizationRates));
-    if(!interface->deviceGetUtilizationRates) {
+    if (!interface->deviceGetUtilizationRates) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceSetPersistenceMode.
     interface->deviceSetPersistenceMode =
         dlsym(interface->handle, STR(nvmlDeviceSetPersistenceMode));
-    if(!interface->deviceSetPersistenceMode) {
+    if (!interface->deviceSetPersistenceMode) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetVgpuMetadata.
     interface->deviceGetVgpuMetadata =
         dlsym(interface->handle, STR(nvmlDeviceGetVgpuMetadata));
-    if(!interface->deviceGetVgpuMetadata) {
+    if (!interface->deviceGetVgpuMetadata) {
         goto SymbolError;
     }
-
     // Load nvmlVgpuInstanceGetMetadata.
     interface->vgpuInstanceGetMetadata =
         dlsym(interface->handle, STR(nvmlVgpuInstanceGetMetadata));
-    if(!interface->vgpuInstanceGetMetadata) {
+    if (!interface->vgpuInstanceGetMetadata) {
         goto SymbolError;
     }
-
     // Load nvmlDeviceGetActiveVgpus.
     interface->deviceGetActiveVgpus =
         dlsym(interface->handle, STR(nvmlDeviceGetActiveVgpus));
-    if(!interface->deviceGetActiveVgpus) {
+    if (!interface->deviceGetActiveVgpus) {
         goto SymbolError;
     }
-
     // Load nvmlVgpuInstanceGetVmID.
     interface->vgpuInstanceGetVmID =
         dlsym(interface->handle, STR(nvmlVgpuInstanceGetVmID));
-    if(!interface->vgpuInstanceGetVmID) {
+    if (!interface->vgpuInstanceGetVmID) {
         goto SymbolError;
     }
-
     // Load nvmlVgpuInstanceGetUUID.
     interface->vgpuInstanceGetUUID =
         dlsym(interface->handle, STR(nvmlVgpuInstanceGetUUID));
-    if(!interface->vgpuInstanceGetUUID) {
+    if (!interface->vgpuInstanceGetUUID) {
         goto SymbolError;
     }
-
     // Load nvmlGetVgpuCompatibility.
     interface->getVgpuCompatibility =
         dlsym(interface->handle, STR(nvmlGetVgpuCompatibility));
-    if(!interface->getVgpuCompatibility) {
+    if (!interface->getVgpuCompatibility) {
         goto SymbolError;
     }
 
 
-    ml_interface = (value)interface;
+    ml_interface = (value) interface;
     CAMLreturn(ml_interface);
 
-SymbolError:
+  SymbolError:
     free(interface);
     exn = caml_named_value("Symbol_not_loaded");
     if (exn) {
         caml_raise_with_string(*exn, dlerror());
-    }
-    else {
+    } else {
         caml_failwith(dlerror());
     }
 }
 
-CAMLprim value stub_nvml_close(value ml_interface) {
+CAMLprim value stub_nvml_close(value ml_interface)
+{
     CAMLparam1(ml_interface);
-    nvmlInterface* interface;
+    nvmlInterface *interface;
 
-    interface = (nvmlInterface*)ml_interface;
-    dlclose((void*)(interface->handle));
+    interface = (nvmlInterface *) ml_interface;
+    dlclose((void *) (interface->handle));
     free(interface);
 
     CAMLreturn(Val_unit);
 }
 
-void check_error(nvmlInterface* interface, nvmlReturn_t error) {
+void check_error(nvmlInterface * interface, nvmlReturn_t error)
+{
     if (NVML_SUCCESS != error) {
         caml_failwith(interface->errorString(error));
     }
 }
 
-CAMLprim value stub_nvml_init(value ml_interface) {
+CAMLprim value stub_nvml_init(value ml_interface)
+{
     CAMLparam1(ml_interface);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
 
-    interface = (nvmlInterface*)ml_interface;
+    interface = (nvmlInterface *) ml_interface;
     error = interface->init();
     check_error(interface, error);
 
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_nvml_shutdown(value ml_interface) {
+CAMLprim value stub_nvml_shutdown(value ml_interface)
+{
     CAMLparam1(ml_interface);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
 
-    interface = (nvmlInterface*)ml_interface;
+    interface = (nvmlInterface *) ml_interface;
     error = interface->shutdown();
     check_error(interface, error);
 
     CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_nvml_device_get_count(value ml_interface) {
+CAMLprim value stub_nvml_device_get_count(value ml_interface)
+{
     CAMLparam1(ml_interface);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     unsigned int count;
 
-    interface = (nvmlInterface*)ml_interface;
+    interface = (nvmlInterface *) ml_interface;
     error = interface->deviceGetCount(&count);
     check_error(interface, error);
 
     CAMLreturn(Val_int(count));
 }
 
-CAMLprim value stub_nvml_device_get_handle_by_index(
-        value ml_interface,
-        value ml_index) {
+CAMLprim value
+stub_nvml_device_get_handle_by_index(value ml_interface, value ml_index)
+{
     CAMLparam2(ml_interface, ml_index);
     CAMLlocal1(ml_device);
 
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     unsigned int index;
     nvmlDevice_t device;
 
-    interface = (nvmlInterface*)ml_interface;
+    interface = (nvmlInterface *) ml_interface;
     index = Int_val(ml_index);
     error = interface->deviceGetHandleByIndex(index, &device);
     check_error(interface, error);
 
     unsigned int deviceSize = sizeof(nvmlDevice_t);
     ml_device = caml_alloc_string(deviceSize);
-    memcpy(String_val(ml_device),
-        &device, deviceSize);
+    memcpy(String_val(ml_device), &device, deviceSize);
 
     CAMLreturn(ml_device);
 }
 
-CAMLprim value stub_nvml_device_get_handle_by_pci_bus_id(
-        value ml_interface,
-        value ml_pci_bus_id) {
+CAMLprim value
+stub_nvml_device_get_handle_by_pci_bus_id(value ml_interface,
+                                          value ml_pci_bus_id)
+{
     CAMLparam2(ml_interface, ml_pci_bus_id);
     CAMLlocal1(ml_device);
 
     nvmlReturn_t error;
-    nvmlInterface* interface;
-    char* pciBusId;
+    nvmlInterface *interface;
+    char *pciBusId;
     nvmlDevice_t device;
 
-    interface = (nvmlInterface*)ml_interface;
+    interface = (nvmlInterface *) ml_interface;
     pciBusId = String_val(ml_pci_bus_id);
     error = interface->deviceGetHandleByPciBusId(pciBusId, &device);
     check_error(interface, error);
-    
+
     unsigned int deviceSize = sizeof(nvmlDevice_t);
     ml_device = caml_alloc_string(deviceSize);
-    memcpy(String_val(ml_device),
-        &device, deviceSize);
+    memcpy(String_val(ml_device), &device, deviceSize);
 
     CAMLreturn(ml_device);
 }
 
 
-CAMLprim value stub_nvml_device_get_memory_info(
-        value ml_interface,
-        value ml_device) {
+CAMLprim value
+stub_nvml_device_get_memory_info(value ml_interface, value ml_device)
+{
     CAMLparam2(ml_interface, ml_device);
     CAMLlocal1(ml_memory_info);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlMemory_t memory_info;
     nvmlDevice_t device;
 
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
-    error =
-        interface->deviceGetMemoryInfo(device, &memory_info);
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
+    error = interface->deviceGetMemoryInfo(device, &memory_info);
     check_error(interface, error);
 
     ml_memory_info = caml_alloc(3, 0);
@@ -328,20 +327,19 @@ CAMLprim value stub_nvml_device_get_memory_info(
     CAMLreturn(ml_memory_info);
 }
 
-CAMLprim value stub_nvml_device_get_pci_info(
-        value ml_interface,
-        value ml_device) {
+CAMLprim value
+stub_nvml_device_get_pci_info(value ml_interface, value ml_device)
+{
     CAMLparam2(ml_interface, ml_device);
     CAMLlocal1(ml_pci_info);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlPciInfo_t pci_info;
     nvmlDevice_t device;
 
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
-    error =
-        interface->deviceGetPciInfo(device, &pci_info);
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
+    error = interface->deviceGetPciInfo(device, &pci_info);
     check_error(interface, error);
 
     ml_pci_info = caml_alloc(6, 0);
@@ -355,53 +353,53 @@ CAMLprim value stub_nvml_device_get_pci_info(
     CAMLreturn(ml_pci_info);
 }
 
-CAMLprim value stub_nvml_device_get_temperature(
-        value ml_interface,
-        value ml_device) {
+CAMLprim value
+stub_nvml_device_get_temperature(value ml_interface, value ml_device)
+{
     CAMLparam2(ml_interface, ml_device);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     unsigned int temp;
     nvmlDevice_t device;
 
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
-    error =
-        interface->deviceGetTemperature(device, NVML_TEMPERATURE_GPU, &temp);
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
+    error = interface->deviceGetTemperature(device, NVML_TEMPERATURE_GPU,
+                                            &temp);
     check_error(interface, error);
 
     CAMLreturn(Val_int(temp));
 }
 
-CAMLprim value stub_nvml_device_get_power_usage(
-        value ml_interface,
-        value ml_device) {
+CAMLprim value
+stub_nvml_device_get_power_usage(value ml_interface, value ml_device)
+{
     CAMLparam2(ml_interface, ml_device);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlDevice_t device;
     unsigned int power_usage;
 
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
     error = interface->deviceGetPowerUsage(device, &power_usage);
     check_error(interface, error);
 
     CAMLreturn(Val_int(power_usage));
 }
 
-CAMLprim value stub_nvml_device_get_utilization_rates(
-        value ml_interface,
-        value ml_device) {
+CAMLprim value
+stub_nvml_device_get_utilization_rates(value ml_interface, value ml_device)
+{
     CAMLparam2(ml_interface, ml_device);
     CAMLlocal1(ml_utilization);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlDevice_t device;
     nvmlUtilization_t utilization;
 
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
     error = interface->deviceGetUtilizationRates(device, &utilization);
     check_error(interface, error);
 
@@ -412,19 +410,19 @@ CAMLprim value stub_nvml_device_get_utilization_rates(
     CAMLreturn(ml_utilization);
 }
 
-CAMLprim value stub_nvml_device_set_persistence_mode(
-        value ml_interface,
-        value ml_device,
-        value ml_mode) {
+CAMLprim value
+stub_nvml_device_set_persistence_mode(value ml_interface,
+                                      value ml_device, value ml_mode)
+{
     CAMLparam3(ml_interface, ml_device, ml_mode);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlDevice_t device;
     nvmlEnableState_t mode;
 
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
-    mode = (nvmlEnableState_t)(Int_val(ml_mode));
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
+    mode = (nvmlEnableState_t) (Int_val(ml_mode));
     error = interface->deviceSetPersistenceMode(device, mode);
     check_error(interface, error);
 
@@ -432,33 +430,44 @@ CAMLprim value stub_nvml_device_set_persistence_mode(
 }
 
 
-CAMLprim value stub_nvml_device_get_pgpu_metadata(
-        value ml_interface, 
-        value ml_device) {
+CAMLprim value
+stub_nvml_device_get_pgpu_metadata(value ml_interface, value ml_device)
+{
     CAMLparam2(ml_interface, ml_device);
     CAMLlocal1(ml_pgpu_metadata);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlDevice_t device;
     unsigned int pgpuMetadataSize = 0;
-    nvmlVgpuPgpuMetadata_t* pgpuMetadata = NULL;
+    nvmlVgpuPgpuMetadata_t *pgpuMetadata = NULL;
 
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
 
     // Get metadata dynamically increasing the buffer size
     int dummy;
     do {
-        error = interface->deviceGetVgpuMetadata(
-            device,
-            (pgpuMetadata)?pgpuMetadata:(nvmlVgpuPgpuMetadata_t*) &dummy,
-            &pgpuMetadataSize);
-        if ((error == NVML_ERROR_INSUFFICIENT_SIZE) && (pgpuMetadataSize > 0)) {
-            if (pgpuMetadata) { free(pgpuMetadata); }
-            pgpuMetadata = (nvmlVgpuPgpuMetadata_t*) malloc(pgpuMetadataSize);
-            if (!pgpuMetadata) { check_error(interface, NVML_ERROR_MEMORY); }
+        error = interface->deviceGetVgpuMetadata(device,
+                                                 (pgpuMetadata) ?
+                                                 pgpuMetadata
+                                                 :
+                                                 (nvmlVgpuPgpuMetadata_t
+                                                  *) & dummy,
+                                                 &pgpuMetadataSize);
+        if ((error == NVML_ERROR_INSUFFICIENT_SIZE)
+            && (pgpuMetadataSize > 0)) {
+            if (pgpuMetadata) {
+                free(pgpuMetadata);
+            }
+            pgpuMetadata = (nvmlVgpuPgpuMetadata_t *)
+                malloc(pgpuMetadataSize);
+            if (!pgpuMetadata) {
+                check_error(interface, NVML_ERROR_MEMORY);
+            }
         }
-    } while ((error == NVML_ERROR_INSUFFICIENT_SIZE) && (pgpuMetadataSize > 0));
+    }
+    while ((error == NVML_ERROR_INSUFFICIENT_SIZE)
+           && (pgpuMetadataSize > 0));
     if (error != NVML_SUCCESS) {
         free(pgpuMetadata);
         check_error(interface, error);
@@ -471,34 +480,44 @@ CAMLprim value stub_nvml_device_get_pgpu_metadata(
     CAMLreturn(ml_pgpu_metadata);
 }
 
-CAMLprim value stub_nvml_get_vgpu_metadata(
-        value ml_interface,
-        value ml_vgpu_instance)
+CAMLprim value
+stub_nvml_get_vgpu_metadata(value ml_interface, value ml_vgpu_instance)
 {
     CAMLparam2(ml_interface, ml_vgpu_instance);
     CAMLlocal1(ml_vgpu_metadata);
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlVgpuInstance_t vgpu;
     unsigned int vgpuMetadataSize = 0;
-    nvmlVgpuMetadata_t* vgpuMetadata = NULL;
+    nvmlVgpuMetadata_t *vgpuMetadata = NULL;
 
-    interface = (nvmlInterface*)ml_interface;
-    vgpu = (nvmlVgpuInstance_t)(Int_val(ml_vgpu_instance));
+    interface = (nvmlInterface *) ml_interface;
+    vgpu = (nvmlVgpuInstance_t) (Int_val(ml_vgpu_instance));
 
     // Get metadata dynamically increasing the buffer size
     int dummy;
     do {
-        error = interface->vgpuInstanceGetMetadata(
-            vgpu,
-            vgpuMetadata ? vgpuMetadata : (nvmlVgpuMetadata_t*) &dummy,
-            &vgpuMetadataSize);
-        if ((error == NVML_ERROR_INSUFFICIENT_SIZE) && (vgpuMetadataSize > 0)) {
-            if (vgpuMetadata) { free(vgpuMetadata); }
-            vgpuMetadata = (nvmlVgpuMetadata_t*) malloc(vgpuMetadataSize);
-            if (!vgpuMetadata) { check_error(interface, NVML_ERROR_MEMORY); }
+        error = interface->vgpuInstanceGetMetadata(vgpu,
+                                                   vgpuMetadata ?
+                                                   vgpuMetadata
+                                                   :
+                                                   (nvmlVgpuMetadata_t
+                                                    *) & dummy,
+                                                   &vgpuMetadataSize);
+        if ((error == NVML_ERROR_INSUFFICIENT_SIZE)
+            && (vgpuMetadataSize > 0)) {
+            if (vgpuMetadata) {
+                free(vgpuMetadata);
+            }
+            vgpuMetadata = (nvmlVgpuMetadata_t *)
+                malloc(vgpuMetadataSize);
+            if (!vgpuMetadata) {
+                check_error(interface, NVML_ERROR_MEMORY);
+            }
         }
-    } while ((error == NVML_ERROR_INSUFFICIENT_SIZE) && (vgpuMetadataSize > 0));
+    }
+    while ((error == NVML_ERROR_INSUFFICIENT_SIZE)
+           && (vgpuMetadataSize > 0));
     if (error != NVML_SUCCESS) {
         free(vgpuMetadata);
         check_error(interface, error);
@@ -514,57 +533,71 @@ CAMLprim value stub_nvml_get_vgpu_metadata(
 
 
 
-CAMLprim value stub_pgpu_metadata_get_pgpu_version(value ml_pgpu_metadata) {
+CAMLprim value stub_pgpu_metadata_get_pgpu_version(value ml_pgpu_metadata)
+{
     CAMLparam1(ml_pgpu_metadata);
     nvmlVgpuPgpuMetadata_t pgpuMetadata;
-    pgpuMetadata = *(nvmlVgpuPgpuMetadata_t*)ml_pgpu_metadata;
+    pgpuMetadata = *(nvmlVgpuPgpuMetadata_t *) ml_pgpu_metadata;
     CAMLreturn(Val_int(pgpuMetadata.version));
 }
 
-CAMLprim value stub_pgpu_metadata_get_pgpu_revision(value ml_pgpu_metadata) {
+CAMLprim value stub_pgpu_metadata_get_pgpu_revision(value ml_pgpu_metadata)
+{
     CAMLparam1(ml_pgpu_metadata);
     nvmlVgpuPgpuMetadata_t pgpuMetadata;
-    pgpuMetadata = *(nvmlVgpuPgpuMetadata_t*)ml_pgpu_metadata;
+    pgpuMetadata = *(nvmlVgpuPgpuMetadata_t *) ml_pgpu_metadata;
     CAMLreturn(Val_int(pgpuMetadata.revision));
 }
 
-CAMLprim value stub_pgpu_metadata_get_pgpu_host_driver_version(value ml_pgpu_metadata) {
+CAMLprim value
+stub_pgpu_metadata_get_pgpu_host_driver_version(value ml_pgpu_metadata)
+{
     CAMLparam1(ml_pgpu_metadata);
     nvmlVgpuPgpuMetadata_t pgpuMetadata;
-    pgpuMetadata = *(nvmlVgpuPgpuMetadata_t*)ml_pgpu_metadata;
+    pgpuMetadata = *(nvmlVgpuPgpuMetadata_t *) ml_pgpu_metadata;
     CAMLreturn(caml_copy_string(pgpuMetadata.hostDriverVersion));
 }
 
 
-CAMLprim value stub_nvml_device_get_active_vgpus(
-        value ml_interface,
-        value ml_device) {
+CAMLprim value
+stub_nvml_device_get_active_vgpus(value ml_interface, value ml_device)
+{
     CAMLparam2(ml_interface, ml_device);
     CAMLlocal2(tail, cons);
 
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlDevice_t device;
-    
+
     unsigned int vgpuCount = 0;
-    nvmlVgpuInstance_t* vgpuInstances = NULL;
-    
-    interface = (nvmlInterface*)ml_interface;
-    device = *(nvmlDevice_t*)ml_device;
+    nvmlVgpuInstance_t *vgpuInstances = NULL;
+
+    interface = (nvmlInterface *) ml_interface;
+    device = *(nvmlDevice_t *) ml_device;
 
     // Get instances dynamically increasing the buffer size
     int dummy;
     do {
-        error = interface->deviceGetActiveVgpus(
-            device,
-            &vgpuCount, 
-            (vgpuInstances)?vgpuInstances:(nvmlVgpuInstance_t*) &dummy);
-        if ((error == NVML_ERROR_INSUFFICIENT_SIZE) && (vgpuCount > 0)) {
-            if (vgpuInstances) { free(vgpuInstances); }
-            vgpuInstances = (nvmlVgpuInstance_t*) malloc(sizeof(nvmlVgpuInstance_t)*vgpuCount);
-            if (!vgpuInstances) { check_error(interface, NVML_ERROR_MEMORY); }
+        error = interface->deviceGetActiveVgpus(device,
+                                                &vgpuCount,
+                                                (vgpuInstances) ?
+                                                vgpuInstances
+                                                :
+                                                (nvmlVgpuInstance_t
+                                                 *) & dummy);
+        if ((error == NVML_ERROR_INSUFFICIENT_SIZE)
+            && (vgpuCount > 0)) {
+            if (vgpuInstances) {
+                free(vgpuInstances);
+            }
+            vgpuInstances = (nvmlVgpuInstance_t *)
+                malloc(sizeof(nvmlVgpuInstance_t) * vgpuCount);
+            if (!vgpuInstances) {
+                check_error(interface, NVML_ERROR_MEMORY);
+            }
         }
-    } while ((error == NVML_ERROR_INSUFFICIENT_SIZE) && (vgpuCount > 0));
+    }
+    while ((error == NVML_ERROR_INSUFFICIENT_SIZE) && (vgpuCount > 0));
     if (error != NVML_SUCCESS) {
         free(vgpuInstances);
         check_error(interface, error);
@@ -573,7 +606,7 @@ CAMLprim value stub_nvml_device_get_active_vgpus(
     tail = Val_emptylist;
 
     int i;
-    for (i = vgpuCount-1; i >= 0; i--) {
+    for (i = vgpuCount - 1; i >= 0; i--) {
         cons = caml_alloc(2, 0);
         Store_field(cons, 0, Val_int(vgpuInstances[i]));
         Store_field(cons, 1, tail);
@@ -584,31 +617,32 @@ CAMLprim value stub_nvml_device_get_active_vgpus(
     CAMLreturn(tail);
 }
 
-CAMLprim value stub_nvml_vgpu_instance_get_vm_id(
-        value ml_interface,
-        value ml_vgpu_instance) {
+CAMLprim value
+stub_nvml_vgpu_instance_get_vm_id(value ml_interface,
+                                  value ml_vgpu_instance)
+{
     CAMLparam2(ml_interface, ml_vgpu_instance);
     CAMLlocal1(ml_vm_id);
 
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlVgpuInstance_t vgpuInstance;
-    
+
     // The VM ID is returned as a string,
     // not exceeding 80 characters in length (including the NUL terminator).
     char vmID[80];
     nvmlVgpuVmIdType_t *vmIdType;
 
-    interface = (nvmlInterface*)ml_interface;
-    vgpuInstance = (nvmlVgpuInstance_t)Int_val(ml_vgpu_instance);
-    
-    vmIdType = (nvmlVgpuVmIdType_t*) malloc(sizeof(nvmlVgpuVmIdType_t));
+    interface = (nvmlInterface *) ml_interface;
+    vgpuInstance = (nvmlVgpuInstance_t) Int_val(ml_vgpu_instance);
+
+    vmIdType = (nvmlVgpuVmIdType_t *) malloc(sizeof(nvmlVgpuVmIdType_t));
     if (!vmIdType) {
         check_error(interface, NVML_ERROR_MEMORY);
     }
 
-    error = interface->vgpuInstanceGetVmID(
-        vgpuInstance, vmID, 80, vmIdType);
+    error = interface->vgpuInstanceGetVmID(vgpuInstance, vmID, 80,
+                                           vmIdType);
     if (error != NVML_SUCCESS) {
         free(vmIdType);
         check_error(interface, error);
@@ -621,72 +655,73 @@ CAMLprim value stub_nvml_vgpu_instance_get_vm_id(
     CAMLreturn(ml_vm_id);
 }
 
-CAMLprim value stub_nvml_vgpu_instance_get_vgpu_uuid(
-        value ml_interface,
-        value ml_vgpu_instance) {
+CAMLprim value
+stub_nvml_vgpu_instance_get_vgpu_uuid(value ml_interface,
+                                      value ml_vgpu_instance)
+{
     CAMLparam2(ml_interface, ml_vgpu_instance);
     CAMLlocal1(ml_vgpu_uuid);
 
     nvmlReturn_t error;
-    nvmlInterface* interface;
+    nvmlInterface *interface;
     nvmlVgpuInstance_t vgpuInstance;
     char uuid[80];
-    
+
     // The VGPU UUID is returned as a string,
     // not exceeding 80 characters in length (including the NUL terminator).
-    interface = (nvmlInterface*)ml_interface;
-    vgpuInstance = (nvmlVgpuInstance_t)Int_val(ml_vgpu_instance);
-    
+    interface = (nvmlInterface *) ml_interface;
+    vgpuInstance = (nvmlVgpuInstance_t) Int_val(ml_vgpu_instance);
+
     error = interface->vgpuInstanceGetUUID(vgpuInstance, uuid, 80);
     if (error != NVML_SUCCESS) {
-      caml_failwith("Failed to obtain UUID.");
-      check_error(interface, error);
+        caml_failwith("Failed to obtain UUID.");
+        check_error(interface, error);
     }
-    
+
     ml_vgpu_uuid = caml_copy_string(uuid);
 
     CAMLreturn(ml_vgpu_uuid);
 }
 
-CAMLprim value stub_nvml_get_pgpu_vgpu_compatibility(
-        value ml_interface,
-        value ml_vgpu_metadata,
-        value ml_pgpu_metadata)
+CAMLprim value
+stub_nvml_get_pgpu_vgpu_compatibility(value ml_interface,
+                                      value ml_vgpu_metadata,
+                                      value ml_pgpu_metadata)
 {
     CAMLparam3(ml_interface, ml_vgpu_metadata, ml_pgpu_metadata);
     CAMLlocal1(ml_vgpu_pgpu_compat_meta);
-    nvmlReturn_t                error;
-    nvmlInterface*              interface;
-    nvmlVgpuPgpuMetadata_t*     pgpuMetadata;
-    nvmlVgpuMetadata_t*         vgpuMetadata;
+    nvmlReturn_t error;
+    nvmlInterface *interface;
+    nvmlVgpuPgpuMetadata_t *pgpuMetadata;
+    nvmlVgpuMetadata_t *vgpuMetadata;
     nvmlVgpuPgpuCompatibility_t vgpuCompatibility;
 
-    interface    = (nvmlInterface*)           ml_interface;
-    vgpuMetadata = (nvmlVgpuMetadata_t*)      ml_vgpu_metadata;
-    pgpuMetadata = (nvmlVgpuPgpuMetadata_t*)  ml_pgpu_metadata;
+    interface = (nvmlInterface *) ml_interface;
+    vgpuMetadata = (nvmlVgpuMetadata_t *) ml_vgpu_metadata;
+    pgpuMetadata = (nvmlVgpuPgpuMetadata_t *) ml_pgpu_metadata;
 
-    error = interface->getVgpuCompatibility(
-        vgpuMetadata,
-        pgpuMetadata,
-        &vgpuCompatibility);
+    error = interface->getVgpuCompatibility(vgpuMetadata,
+                                            pgpuMetadata,
+                                            &vgpuCompatibility);
     check_error(interface, error);
 
     size_t compatSize = sizeof(nvmlVgpuPgpuCompatibility_t);
     ml_vgpu_pgpu_compat_meta = caml_alloc_string(compatSize);
     memcpy(String_val(ml_vgpu_pgpu_compat_meta),
-        &vgpuCompatibility, compatSize);
+           &vgpuCompatibility, compatSize);
 
     CAMLreturn(ml_vgpu_pgpu_compat_meta);
 }
 
 
-CAMLprim value stub_vgpu_compat_get_vm_compat(value ml_vgpu_compat) {
+CAMLprim value stub_vgpu_compat_get_vm_compat(value ml_vgpu_compat)
+{
     CAMLparam1(ml_vgpu_compat);
     CAMLlocal2(tail, cons);
-    nvmlVgpuPgpuCompatibility_t* vgpuCompatibility;
+    nvmlVgpuPgpuCompatibility_t *vgpuCompatibility;
     int mask;
 
-    vgpuCompatibility = (nvmlVgpuPgpuCompatibility_t*)ml_vgpu_compat;
+    vgpuCompatibility = (nvmlVgpuPgpuCompatibility_t *) ml_vgpu_compat;
     mask = vgpuCompatibility->vgpuVmCompatibility;
 
     tail = Val_emptylist;
@@ -725,13 +760,14 @@ CAMLprim value stub_vgpu_compat_get_vm_compat(value ml_vgpu_compat) {
     CAMLreturn(tail);
 }
 
-CAMLprim value stub_vgpu_compat_get_pgpu_compat_limit(value ml_vgpu_compat) {
+CAMLprim value stub_vgpu_compat_get_pgpu_compat_limit(value ml_vgpu_compat)
+{
     CAMLparam1(ml_vgpu_compat);
     CAMLlocal2(tail, cons);
-    nvmlVgpuPgpuCompatibility_t* vgpuCompatibility;
+    nvmlVgpuPgpuCompatibility_t *vgpuCompatibility;
     int mask;
 
-    vgpuCompatibility = (nvmlVgpuPgpuCompatibility_t*)ml_vgpu_compat;
+    vgpuCompatibility = (nvmlVgpuPgpuCompatibility_t *) ml_vgpu_compat;
     mask = vgpuCompatibility->compatibilityLimitCode;
 
     tail = Val_emptylist;

--- a/stubs/nvml_stubs.c
+++ b/stubs/nvml_stubs.c
@@ -58,7 +58,7 @@ CAMLprim value stub_nvml_open(value unit)
     CAMLlocal1(ml_interface);
 
     nvmlInterface *interface;
-    value *exn;
+    const value *exn;
 
     interface = malloc(sizeof(nvmlInterface));
     if (!interface)
@@ -272,8 +272,8 @@ stub_nvml_device_get_handle_by_index(value ml_interface, value ml_index)
     check_error(interface, error);
 
     unsigned int deviceSize = sizeof(nvmlDevice_t);
-    ml_device = caml_alloc_string(deviceSize);
-    memcpy(String_val(ml_device), &device, deviceSize);
+    ml_device =
+        caml_alloc_initialized_string(deviceSize, (const char *) &device);
 
     CAMLreturn(ml_device);
 }
@@ -287,7 +287,7 @@ stub_nvml_device_get_handle_by_pci_bus_id(value ml_interface,
 
     nvmlReturn_t error;
     nvmlInterface *interface;
-    char *pciBusId;
+    const char *pciBusId;
     nvmlDevice_t device;
 
     interface = (nvmlInterface *) ml_interface;
@@ -296,9 +296,8 @@ stub_nvml_device_get_handle_by_pci_bus_id(value ml_interface,
     check_error(interface, error);
 
     unsigned int deviceSize = sizeof(nvmlDevice_t);
-    ml_device = caml_alloc_string(deviceSize);
-    memcpy(String_val(ml_device), &device, deviceSize);
-
+    ml_device =
+        caml_alloc_initialized_string(deviceSize, (const char *) &device);
     CAMLreturn(ml_device);
 }
 
@@ -461,8 +460,9 @@ stub_nvml_device_get_pgpu_metadata(value ml_interface, value ml_device)
         free(metadata);
         check_error(interface, error);
     }
-    ml_metadata = caml_alloc_string(metadataSize);
-    memcpy(String_val(ml_metadata), metadata, metadataSize);
+    ml_metadata =
+        caml_alloc_initialized_string(metadataSize,
+                                      (const char *) metadata);
     free(metadata);
 
     CAMLreturn(ml_metadata);
@@ -502,7 +502,9 @@ stub_nvml_get_vgpu_metadata(value ml_interface, value ml_vgpu_instance)
     }
 
     ml_metadata = caml_alloc_string(metadataSize);
-    memcpy(String_val(ml_metadata), metadata, metadataSize);
+    ml_metadata =
+        caml_alloc_initialized_string(metadataSize,
+                                      (const char *) metadata);
     free(metadata);
 
     CAMLreturn(ml_metadata);
@@ -673,9 +675,9 @@ stub_nvml_get_pgpu_vgpu_compatibility(value ml_interface,
     check_error(interface, error);
 
     size_t compatSize = sizeof(nvmlVgpuPgpuCompatibility_t);
-    ml_vgpu_pgpu_compat_meta = caml_alloc_string(compatSize);
-    memcpy(String_val(ml_vgpu_pgpu_compat_meta),
-           &vgpuCompatibility, compatSize);
+    ml_vgpu_pgpu_compat_meta =
+        caml_alloc_initialized_string(compatSize,
+                                      (const char *) &vgpuCompatibility);
 
     CAMLreturn(ml_vgpu_pgpu_compat_meta);
 }

--- a/test/test_config.ml
+++ b/test/test_config.ml
@@ -138,5 +138,5 @@ let test =
   >::: List.map
          (fun (config_file, expected_result) ->
            config_file >:: fun () -> test_file config_file expected_result
-           )
+         )
          tests


### PR DESCRIPTION
The NVML library is required to query Nvidia GPUs at runtime. This library is loaded dynamically using dlopen(2). Add the capability to attach and detach this library using the xapi-idl IPC mechanism.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>