### PR TITLE
CP-33044 Introduce NVML.{attach,detach}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,5 @@ mock:
 	cp mocks/mock.ml lib/nvml.ml
 	cp mocks/mock.c  stubs/nvml_stubs.c
 
+unmock:
+	git checkout -- lib/nvml.ml stubs/nvml_stubs.c

--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -325,7 +325,10 @@ module Make (Impl : Gpumon_server.IMPLEMENTATION) = struct
     Server.Nvidia.get_pgpu_vgpu_compatibility
       Impl.Nvidia.get_pgpu_vgpu_compatibility ;
     Server.Nvidia.get_pgpu_vm_compatibility
-      Impl.Nvidia.get_pgpu_vm_compatibility
+      Impl.Nvidia.get_pgpu_vm_compatibility ;
+    Server.Nvidia.nvml_attach Impl.Nvidia.attach ;
+    Server.Nvidia.nvml_detach Impl.Nvidia.detach ;
+    Server.Nvidia.nvml_is_attached Impl.Nvidia.is_attached
 end
 
 let () =

--- a/gpumon/gpumon_server.ml
+++ b/gpumon/gpumon_server.ml
@@ -37,6 +37,12 @@ module type IMPLEMENTATION = sig
       -> nvidia_pgpu_metadata
       -> nvidia_vgpu_metadata list
       -> compatibility
+
+    val attach : debug_info -> unit
+
+    val detach : debug_info -> unit
+
+    val is_attached : debug_info -> bool
   end
 end
 
@@ -174,5 +180,15 @@ module Make (I : Interface) : IMPLEMENTATION = struct
     let get_pgpu_vm_compatibility dbg pgpu_address domid pgpu_metadata =
       get_pgpu_vgpu_compatibility dbg pgpu_metadata
         (get_vgpu_metadata dbg domid pgpu_address "")
+
+    let fail exn =
+      raise
+        Gpumon_interface.(Gpumon_error (NvmlFailure (Printexc.to_string exn)))
+
+    let attach _dbg = try Nvml.NVML.attach () with exn -> fail exn
+
+    let detach _dbg = try Nvml.NVML.detach () with exn -> fail exn
+
+    let is_attached _dbg = try Nvml.NVML.is_attached () with exn -> fail exn
   end
 end

--- a/lib/nvml.ml
+++ b/lib/nvml.ml
@@ -135,3 +135,14 @@ let get_vgpu_for_uuid iface vgpu_uuid vgpus =
           None
     )
     vgpus
+
+(* mock implementation *)
+module NVML = struct
+  let attach () = ()
+
+  let detach () = ()
+
+  let is_attached () = true
+
+  let get () : interface option = None
+end

--- a/mocks/mock.ml
+++ b/mocks/mock.ml
@@ -100,3 +100,13 @@ let vgpu_compat_get_pgpu_compat_limit _vgpu_compatibility_t = []
 let get_vgpus_for_vm _iface _device _vm_domid = []
 
 let get_vgpu_for_uuid _iface _vgpu_uuid _vgpus = []
+
+module NVML = struct
+  let attach () = ()
+
+  let detach () = ()
+
+  let is_attached () = true
+
+  let get () : interface option = None
+end


### PR DESCRIPTION
The NVML library is required to query Nvidia GPUs at runtime. This library is loaded dynamically using dlopen(2). Add the capability to attach and detach this library using the xapi-idl IPC mechanism.