### PR TITLE
CP-33044 implement NVML attach/detach

### DIFF
--- a/gpumon/gpumon_server.ml
+++ b/gpumon/gpumon_server.ml
@@ -47,7 +47,7 @@ module type IMPLEMENTATION = sig
 end
 
 module type Interface = sig
-  val interface : Nvml.interface option
+  val interface : unit -> Nvml.interface option
 end
 
 module Make (I : Interface) : IMPLEMENTATION = struct
@@ -60,7 +60,7 @@ module Make (I : Interface) : IMPLEMENTATION = struct
     let host_driver_supporting_migration = 390
 
     let get_interface_exn () =
-      match I.interface with
+      match I.interface () with
       | Some interface ->
           interface
       | None ->

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name gpumon_lib)
  (wrapped false)
- (libraries nvml_stubs rresult xapi-stdext-unix))
+ (libraries nvml_stubs xapi-log rresult xapi-stdext-unix))


### PR DESCRIPTION
The NVML library is required to query Nvidia GPUs at runtime. This library is loaded dynamically using dlopen(2). Add the capability to attach and detach this library using the xapi-idl IPC mechanism. This is experimental and replaced the existing mock implementation.
