### PR TITLE
gpumon: add a unit test to check that gpumon doesn't fail on startup …

### DIFF
--- a/gpumon/dune
+++ b/gpumon/dune
@@ -3,3 +3,7 @@
  (public_name gpumon)
  (libraries gpumon_lib rrdd-plugin threads xapi-idl.gpumon
    xapi-stdext-pervasives xapi-stdext-unix))
+
+(rule
+(alias runtest)
+(action (run ./gpumon.exe --help)))

--- a/gpumon/gpumon.ml
+++ b/gpumon/gpumon.ml
@@ -331,6 +331,8 @@ module Make (Impl : Gpumon_server.IMPLEMENTATION) = struct
     Server.Nvidia.nvml_is_attached Impl.Nvidia.is_attached
 end
 
+let doc = "GPU monitoring daemon"
+
 let () =
   Process.initialise () ;
   let maybe_interface = open_nvml_interface_noexn () in
@@ -360,6 +362,8 @@ let () =
       ~rpc_fn:(Idl.Exn.server Server.implementation)
       ()
   in
+  (* call after setting up RPC server to catch unimplemented API errors early *)
+  Xcp_service.configure ();
   let _ =
     handle_shutdown stop_handler () ;
     start server


### PR DESCRIPTION
…due to unbound API calls

Introduce some minimal CLI parsing (responding to --help with exit 0), and call it after we've attempted to bind the RPC APIs.

If any APIs are not bound this would then raise an exception, that will cause 'make test' to fail.

Useful to catch build issues where rebuilding an old version of gpumon with a newer xapi-idl causes it to fail on startup due to unimplemented APIs.

Tested by commenting out one call in 'bind ()', which caused 'make test' to fail.

(make test is called by gpumon.spec so this should catch this problem entirely at RPM build time instead of host install first-boot time)

It'd be better if this was a compile-time error rather than a 'dune runtest' time error, but that might require extensive changes in rpclib to generate a functor instead of the current way of binding API calls one-at-a-time and then checking whether you bound them all (which can only be a runtime test).